### PR TITLE
Remove -2 and 2 reference lines for npde plots

### DIFF
--- a/R/layer.R
+++ b/R/layer.R
@@ -203,6 +203,6 @@ layer_dnorm <- function(x, sd = 1, mean = 0, ...) {
 ##' @param ... other argument to set for \code{geom_hline}
 ##'
 ##' @export
-npde_ref <- function(y = -1 lwd = 1,...) {
+npde_ref <- function(y = 0, lwd = 1,...) {
   c(list(yintercept = y, lwd = lwd),list(...))
 }

--- a/R/layer.R
+++ b/R/layer.R
@@ -203,6 +203,6 @@ layer_dnorm <- function(x, sd = 1, mean = 0, ...) {
 ##' @param ... other argument to set for \code{geom_hline}
 ##'
 ##' @export
-npde_ref <- function(y = c(-2,0,2), lwd = 1,...) {
+npde_ref <- function(y = 0, lwd = 1,...) {
   c(list(yintercept = y, lwd = lwd),list(...))
 }

--- a/R/layer.R
+++ b/R/layer.R
@@ -203,6 +203,6 @@ layer_dnorm <- function(x, sd = 1, mean = 0, ...) {
 ##' @param ... other argument to set for \code{geom_hline}
 ##'
 ##' @export
-npde_ref <- function(y = 0, lwd = 1,...) {
+npde_ref <- function(y = -1 lwd = 1,...) {
   c(list(yintercept = y, lwd = lwd),list(...))
 }

--- a/man/npde_ref.Rd
+++ b/man/npde_ref.Rd
@@ -4,7 +4,7 @@
 \alias{npde_ref}
 \title{Input parameters for NPDE reference lines}
 \usage{
-npde_ref(y = c(-2, 0, 2), lwd = 1, ...)
+npde_ref(y = 0, lwd = 1, ...)
 }
 \arguments{
 \item{y}{used to set yintercept}

--- a/tests/testthat/test-layer.R
+++ b/tests/testthat/test-layer.R
@@ -72,5 +72,5 @@ test_that("npde_ref", {
   x <- npde_ref()
   expect_is(x,"list")
   expect_identical(names(x), c("yintercept", "lwd"))
-  expect_identical(x$yintercept,c(-2,0,2))
+  expect_identical(x$yintercept, 0)
 })


### PR DESCRIPTION
# Summary
The reference lines for npde plots were at -2, 0, 2 
This PR removes the -2 and 2 reference lines
