### PR TITLE
dv_pred breaks

### DIFF
--- a/R/dv_pred.R
+++ b/R/dv_pred.R
@@ -1,50 +1,50 @@
 
-##' Plot DV versus predicted values
-##'
-##' Plots for `DV` versus population or individual predicted values. `dv_preds`
-##' makes both plots and returns them as a list (more in `details`).
-##'
-##' @param df data frame to plot
-##' @param x character name for x-axis data
-##' @param y character name for y-axis data
-##' @param yname used to form y-axis label
-##' @param xname used to form x-axis label
-##' @param ys see [defy()]
-##' @param xs see [defx()]; note that `xs` defaults to `ys` so (by
-##' default) the scale configuration will be identical; pass both `xs` and `ys`
-##' to have them independently configured
-##' @param loglog if `TRUE`, x- and y-axes will be log-transformed
-##' @param scales if `TRUE`, then the x- and y- axes will be forced
-##' to have the same limits
-##' @param logbr when using log scale, should the tick marks be at `full`-log
-##' intervals or `half`-log intervals? If you pass `null`, the default scales
-##' will be used (which might be identical to `full`). Use `xs` and `ys` to
-##' pass custom scales.
-##' @param ... passed to [scatt()] and [layer_as()]
-##'
-##' @details
-##' Since this function creates a scatter plot, both the `x` and `y` columns
-##' must be numeric.
-##'
-##' `dv_preds` returns a list of two plots, with the result of `dv_pred` in the
-##' first position and the result of `dv_ipred` in the second position.  In
-##' this case, `...` are passed to both functions.
-##'
-##' @examples
-##' df <- pmplots_data_obs()
-##'
-##' dv_pred(df)
-##'
-##' dv_ipred(df, yname="MyDrug (ng/mL)")
-##'
-##' dv_preds(df, yname = "MyDrug (ng/mL)")
-##'
-##' @return
-##' `dv_pred` and `dv_ipred` return a single plot; `dv_preds` returns a list
-##' of plots.
-##'
-##' @md
-##' @export
+#' Plot DV versus predicted values
+#'
+#' Plots for `DV` versus population or individual predicted values. `dv_preds`
+#' makes both plots and returns them as a list (more in `details`).
+#'
+#' @param df data frame to plot
+#' @param x character name for x-axis data
+#' @param y character name for y-axis data
+#' @param yname used to form y-axis label
+#' @param xname used to form x-axis label
+#' @param ys see [defy()]
+#' @param xs see [defx()]; note that `xs` defaults to `ys` so (by
+#' default) the scale configuration will be identical; pass both `xs` and `ys`
+#' to have them independently configured
+#' @param loglog if `TRUE`, x- and y-axes will be log-transformed
+#' @param scales if `TRUE`, then the x- and y- axes will be forced
+#' to have the same limits
+#' @param logbr when using log scale, should the tick marks be at `full`-log
+#' intervals or `half`-log intervals? If you pass `null`, the default scales
+#' will be used (which might be identical to `full`). Use `xs` and `ys` to
+#' pass custom scales.
+#' @param ... passed to [scatt()] and [layer_as()]
+#'
+#' @details
+#' Since this function creates a scatter plot, both the `x` and `y` columns
+#' must be numeric.
+#'
+#' `dv_preds` returns a list of two plots, with the result of `dv_pred` in the
+#' first position and the result of `dv_ipred` in the second position.  In
+#' this case, `...` are passed to both functions.
+#'
+#' @examples
+#' df <- pmplots_data_obs()
+#'
+#' dv_pred(df)
+#'
+#' dv_ipred(df, yname="MyDrug (ng/mL)")
+#'
+#' dv_preds(df, yname = "MyDrug (ng/mL)")
+#'
+#' @return
+#' `dv_pred` and `dv_ipred` return a single plot; `dv_preds` returns a list
+#' of plots.
+#'
+#' @md
+#' @export
 dv_pred <- function(df, x = pm_axis_pred(), y = pm_axis_dv(),
                     yname = "value", xname = "value",
                     ys = list(), xs = ys, loglog = FALSE,
@@ -124,15 +124,15 @@ dv_pred <- function(df, x = pm_axis_pred(), y = pm_axis_dv(),
   layer_as(out, ...) + pm_labs(x = xlab, y = ylab)
 }
 
-##' @export
-##' @rdname dv_pred
+#' @export
+#' @rdname dv_pred
 dv_ipred <- function(df, x = pm_axis_ipred(), ...) {
   out <- dv_pred(df, x = x, ...)
   layer_as(out,...)
 }
 
-##' @export
-##' @rdname dv_pred
+#' @export
+#' @rdname dv_pred
 dv_preds <- function(df, ...) {
   list(dv_pred(df, ...), dv_ipred(df, ...))
 }

--- a/R/dv_pred.R
+++ b/R/dv_pred.R
@@ -64,14 +64,14 @@ dv_pred <- function(df, x = pm_axis_pred(), y = pm_axis_dv(),
   xlab <- x[2]
   ylab <- y[2]
 
-  require_numeric(df,x[1])
-  require_numeric(df,y[1])
+  require_numeric(df, x[1])
+  require_numeric(df, y[1])
 
   inx <- xs
   iny <- ys
 
-  xs <- update_list(defx(),xs)
-  ys <- update_list(defy(),ys)
+  xs <- update_list(defx(), xs)
+  ys <- update_list(defy(), ys)
 
   x <- x[1]
   y <- y[1]
@@ -80,13 +80,13 @@ dv_pred <- function(df, x = pm_axis_pred(), y = pm_axis_dv(),
     xs$trans <- "log10"
     ys$trans <- "log10"
     logbr <- match.arg(logbr)
-    if(logbr=="half") {
+    if(logbr == "half") {
       log_breaks <- logbr3()
     }
-    if(logbr=="full") {
+    if(logbr == "full") {
       log_breaks <- logbr()
     }
-    if(logbr=="null") {
+    if(logbr == "null") {
       log_breaks <- NULL
     }
   }
@@ -108,7 +108,7 @@ dv_pred <- function(df, x = pm_axis_pred(), y = pm_axis_dv(),
   }
 
   if(scales == "fixed") {
-    lim <- get_limits(df,x,y)
+    lim <- get_limits(df, x, y)
 
     if(.miss("limits", inx)) {
       xs$limits <- lim

--- a/R/dv_pred.R
+++ b/R/dv_pred.R
@@ -1,34 +1,34 @@
 
 ##' Plot DV versus predicted values
 ##'
+##' Plots for `DV` versus population or individual predicted values. `dv_preds`
+##' makes both plots and returns them as a list (more in `details`).
+##'
 ##' @param df data frame to plot
 ##' @param x character name for x-axis data
 ##' @param y character name for y-axis data
 ##' @param yname used to form y-axis label
 ##' @param xname used to form x-axis label
-##' @param ys see \code{\link{defy}}
-##' @param xs see \code{\link{defx}}; note that `xs` defaults to `ys` so (by
+##' @param ys see [defy()]
+##' @param xs see [defx()]; note that `xs` defaults to `ys` so (by
 ##' default) the scale configuration will be identical; pass both `xs` and `ys`
 ##' to have them independently configured
-##' @param loglog if \code{TRUE}, x- and y-axes will be log-transformed
-##' @param scales if \code{TRUE}, then the x- and y- axes will be forced
+##' @param loglog if `TRUE`, x- and y-axes will be log-transformed
+##' @param scales if `TRUE`, then the x- and y- axes will be forced
 ##' to have the same limits
 ##' @param logbr when using log scale, should the tick marks be at `full`-log
 ##' intervals or `half`-log intervals? If you pass `null`, the default scales
 ##' will be used (which might be identical to `full`). Use `xs` and `ys` to
 ##' pass custom scales.
-##' @param ... passed to \code{\link{scatt}} and \code{\link{layer_as}}
+##' @param ... passed to [scatt()] and [layer_as()]
 ##'
 ##' @details
-##' Since this function creates a scatter plot,
-##' both the \code{x} and \code{y} columns must
-##' be numeric.
+##' Since this function creates a scatter plot, both the `x` and `y` columns
+##' must be numeric.
 ##'
-##' \code{dv_preds} returns a list of two plots, with
-##' the result of \code{dv_pred} in the first position
-##' and the result of \code{dv_ipred} in the
-##' second position.  In this case, \code{...} are
-##' passed to both functions.
+##' `dv_preds` returns a list of two plots, with the result of `dv_pred` in the
+##' first position and the result of `dv_ipred` in the second position.  In
+##' this case, `...` are passed to both functions.
 ##'
 ##' @examples
 ##' df <- pmplots_data_obs()
@@ -39,8 +39,11 @@
 ##'
 ##' dv_preds(df, yname = "MyDrug (ng/mL)")
 ##'
-##' @return A single plot.
+##' @return
+##' `dv_pred` and `dv_ipred` return a single plot; `dv_preds` returns a list
+##' of plots.
 ##'
+##' @md
 ##' @export
 dv_pred <- function(df, x = pm_axis_pred(), y = pm_axis_dv(),
                     yname = "value", xname = "value",

--- a/R/dv_pred.R
+++ b/R/dv_pred.R
@@ -4,13 +4,19 @@
 ##' @param df data frame to plot
 ##' @param x character name for x-axis data
 ##' @param y character name for y-axis data
-##' @param xname used to form x-axis label
 ##' @param yname used to form y-axis label
-##' @param xs see \code{\link{defx}}
+##' @param xname used to form x-axis label
 ##' @param ys see \code{\link{defy}}
+##' @param xs see \code{\link{defx}}; note that `xs` defaults to `ys` so (by
+##' default) the scale configuration will be identical; pass both `xs` and `ys`
+##' to have them independently configured
 ##' @param loglog if \code{TRUE}, x- and y-axes will be log-transformed
 ##' @param scales if \code{TRUE}, then the x- and y- axes will be forced
 ##' to have the same limits
+##' @param logbr when using log scale, should the tick marks be at `full`-log
+##' intervals or `half`-log intervals? If you pass `null`, the default scales
+##' will be used (which might be identical to `full`). Use `xs` and `ys` to
+##' pass custom scales.
 ##' @param ... passed to \code{\link{scatt}} and \code{\link{layer_as}}
 ##'
 ##' @details
@@ -36,11 +42,11 @@
 ##' @return A single plot.
 ##'
 ##' @export
-dv_pred <- function(df, x=pm_axis_pred(), y=pm_axis_dv(),
-                    yname="value", xname="value",
-                    xs = list(), ys = list(), loglog = FALSE,
-                    scales = c("fixed", "free"),
-                    logbr = c("full", "half"), ...) {
+dv_pred <- function(df, x = pm_axis_pred(), y = pm_axis_dv(),
+                    yname = "value", xname = "value",
+                    ys = list(), xs = ys, loglog = FALSE,
+                    scales = c("fixed", "free", "null"),
+                    logbr = c("full", "half", "null"), ...) {
 
   scales <- match.arg(scales)
 
@@ -68,13 +74,17 @@ dv_pred <- function(df, x=pm_axis_pred(), y=pm_axis_dv(),
   y <- y[1]
 
   if(loglog) {
-    xs$trans <- "log"
-    ys$trans <- "log"
+    xs$trans <- "log10"
+    ys$trans <- "log10"
     logbr <- match.arg(logbr)
     if(logbr=="half") {
       log_breaks <- logbr3()
-    } else {
+    }
+    if(logbr=="full") {
       log_breaks <- logbr()
+    }
+    if(logbr=="null") {
+      log_breaks <- NULL
     }
   }
 

--- a/R/dv_pred.R
+++ b/R/dv_pred.R
@@ -38,8 +38,9 @@
 ##' @export
 dv_pred <- function(df, x=pm_axis_pred(), y=pm_axis_dv(),
                     yname="value", xname="value",
-                    xs = list(), ys = list(), loglog=FALSE,
-                    scales = c("fixed", "free"), ...) {
+                    xs = list(), ys = list(), loglog = FALSE,
+                    scales = c("fixed", "free"),
+                    logbr = c("full", "half"), ...) {
 
   scales <- match.arg(scales)
 
@@ -66,25 +67,30 @@ dv_pred <- function(df, x=pm_axis_pred(), y=pm_axis_dv(),
   x <- x[1]
   y <- y[1]
 
-
   if(loglog) {
     xs$trans <- "log"
     ys$trans <- "log"
+    logbr <- match.arg(logbr)
+    if(logbr=="half") {
+      log_breaks <- logbr3()
+    } else {
+      log_breaks <- logbr()
+    }
   }
 
   if(xs$trans %in% c("log", "log10")) {
     xkp <- df[,x] > 0
-    df <- dplyr::filter(df,xkp)
+    df <- dplyr::filter(df, xkp)
     if(.miss("breaks", inx)) {
-      xs$breaks <- logbr3()
+      xs$breaks <- log_breaks
     }
   }
 
   if(ys$trans %in% c("log", "log10")) {
     ykp <- df[,y] > 0
-    df <- dplyr::filter(df,ykp)
+    df <- dplyr::filter(df, ykp)
     if(.miss("breaks", iny)) {
-      ys$breaks <- logbr3()
+      ys$breaks <- log_breaks
     }
   }
 

--- a/man/dv_pred.Rd
+++ b/man/dv_pred.Rd
@@ -12,10 +12,11 @@ dv_pred(
   y = pm_axis_dv(),
   yname = "value",
   xname = "value",
-  xs = list(),
   ys = list(),
+  xs = ys,
   loglog = FALSE,
-  scales = c("fixed", "free"),
+  scales = c("fixed", "free", "null"),
+  logbr = c("full", "half", "null"),
   ...
 )
 
@@ -34,14 +35,21 @@ dv_preds(df, ...)
 
 \item{xname}{used to form x-axis label}
 
-\item{xs}{see \code{\link{defx}}}
-
 \item{ys}{see \code{\link{defy}}}
+
+\item{xs}{see \code{\link{defx}}; note that \code{xs} defaults to \code{ys} so (by
+default) the scale configuration will be identical; pass both \code{xs} and \code{ys}
+to have them independently configured}
 
 \item{loglog}{if \code{TRUE}, x- and y-axes will be log-transformed}
 
 \item{scales}{if \code{TRUE}, then the x- and y- axes will be forced
 to have the same limits}
+
+\item{logbr}{when using log scale, should the tick marks be at \code{full}-log
+intervals or \code{half}-log intervals? If you pass \code{null}, the default scales
+will be used (which might be identical to \code{full}). Use \code{xs} and \code{ys} to
+pass custom scales.}
 
 \item{...}{passed to \code{\link{scatt}} and \code{\link{layer_as}}}
 }

--- a/man/dv_pred.Rd
+++ b/man/dv_pred.Rd
@@ -35,9 +35,9 @@ dv_preds(df, ...)
 
 \item{xname}{used to form x-axis label}
 
-\item{ys}{see \code{\link{defy}}}
+\item{ys}{see \code{\link[=defy]{defy()}}}
 
-\item{xs}{see \code{\link{defx}}; note that \code{xs} defaults to \code{ys} so (by
+\item{xs}{see \code{\link[=defx]{defx()}}; note that \code{xs} defaults to \code{ys} so (by
 default) the scale configuration will be identical; pass both \code{xs} and \code{ys}
 to have them independently configured}
 
@@ -51,24 +51,23 @@ intervals or \code{half}-log intervals? If you pass \code{null}, the default sca
 will be used (which might be identical to \code{full}). Use \code{xs} and \code{ys} to
 pass custom scales.}
 
-\item{...}{passed to \code{\link{scatt}} and \code{\link{layer_as}}}
+\item{...}{passed to \code{\link[=scatt]{scatt()}} and \code{\link[=layer_as]{layer_as()}}}
 }
 \value{
-A single plot.
+\code{dv_pred} and \code{dv_ipred} return a single plot; \code{dv_preds} returns a list
+of plots.
 }
 \description{
-Plot DV versus predicted values
+Plots for \code{DV} versus population or individual predicted values. \code{dv_preds}
+makes both plots and returns them as a list (more in \code{details}).
 }
 \details{
-Since this function creates a scatter plot,
-both the \code{x} and \code{y} columns must
-be numeric.
+Since this function creates a scatter plot, both the \code{x} and \code{y} columns
+must be numeric.
 
-\code{dv_preds} returns a list of two plots, with
-the result of \code{dv_pred} in the first position
-and the result of \code{dv_ipred} in the
-second position.  In this case, \code{...} are
-passed to both functions.
+\code{dv_preds} returns a list of two plots, with the result of \code{dv_pred} in the
+first position and the result of \code{dv_ipred} in the second position.  In
+this case, \code{...} are passed to both functions.
 }
 \examples{
 df <- pmplots_data_obs()

--- a/tests/testthat/test-pm.R
+++ b/tests/testthat/test-pm.R
@@ -81,10 +81,14 @@ test_that("dv pred", {
   p <- dv_preds(df)
   expect_is(p,"list")
   expect_equal(length(p),2)
+
+  form <- formals(dv_pred)
+  expect_equal(form$logbr,  expr(c("full", "half", "null")))
+  p1 <- dv_pred(df, logbr="null", loglog = TRUE)
+  expect_is(p1, "gg")
+  p2 <- dv_pred(df, logbr="full", loglog = TRUE)
+  expect_is(p2, "gg")
 })
-
-
-
 
 test_that("red pred", {
   p <- res_pred(df)


### PR DESCRIPTION
# Summary 
- adds logbr argument to pick between full and half-log breaks
  - full means tickmarks are full log intervals
  - half means tickmarks at half-log intervals
  - null mean don't force anything; let `scales` figure it out
- custom breaks can still be passed through xs and ys etc
- make the `xs` argument default to the value in `ys`
- refactored the documentation too
