### PR TITLE
drop cowplot; use patchwork

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,88 +1,6 @@
 ---
 kind: pipeline
 type: docker
-name: mpn:latest
-
-platform:
-  os: linux
-  arch: amd64
-
-steps:
-- name: pull
-  image: omerxx/drone-ecr-auth
-  commands:
-  - $(aws ecr get-login --no-include-email --region us-east-1)
-  - docker pull 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.0:latest
-  - docker pull 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.1:latest
-  volumes:
-  - name: docker.sock
-    path: /var/run/docker.sock
-
-- name: "Check package: R 4.0"
-  pull: never
-  image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.0:latest
-  commands:
-  - R -s -e 'devtools::install_deps(upgrade = '"'"'never'"'"')'
-  - R -s -e 'devtools::check(env_vars = c("NOT_CRAN" = "true"))'
-
-
-- name: "Check package: R 4.1"
-  pull: never
-  image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.1:latest
-  commands:
-  - R -s -e 'devtools::install_deps(upgrade = '"'"'never'"'"')'
-  - R -s -e 'devtools::check(env_vars = c("NOT_CRAN" = "true"))'
-
-volumes:
-- name: docker.sock
-  host:
-    path: /var/run/docker.sock
-
-trigger:
-  event:
-    exclude:
-    - promote
-
----
-kind: pipeline
-type: docker
-name: mpn:oldest
-
-platform:
-  os: linux
-  arch: amd64
-
-# this will help test pre-dplyr 1.0 compat
-steps:
-- name: pull
-  image: omerxx/drone-ecr-auth
-  commands:
-  - $(aws ecr get-login --no-include-email --region us-east-1)
-  - docker pull 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.0:2020-05-27
-  volumes:
-  - name: docker.sock
-    path: /var/run/docker.sock
-
-- name: "Check package: R 4.0"
-  pull: never
-  image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.0:2020-05-27
-  commands:
-  - R -s -e 'devtools::install_deps(upgrade = '"'"'never'"'"')'
-  - R -s -e 'devtools::check(env_vars = c("NOT_CRAN" = "true"))'
-
-volumes:
-- name: docker.sock
-  host:
-    path: /var/run/docker.sock
-
-trigger:
-  event:
-    exclude:
-    - promote
-
----
-kind: pipeline
-type: docker
 name: cran-latest
 
 platform:
@@ -95,7 +13,6 @@ steps:
   commands:
   - $(aws ecr get-login --no-include-email --region us-east-1)
   - docker pull 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.0:cran-latest
-  - docker pull 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.1:cran-latest
   volumes:
   - name: docker.sock
     path: /var/run/docker.sock
@@ -105,57 +22,26 @@ steps:
   image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.0:cran-latest
   commands:
   - R -s -e 'devtools::install_deps(upgrade = '"'"'always'"'"')'
-  - R -s -e 'devtools::load_all(); sessioninfo::session_info()'
+  #- R -s -e 'devtools::load_all(); sessioninfo::session_info()'
   - R -s -e 'devtools::check(env_vars = c("NOT_CRAN" = "true"))'
+  environment:
+    USER: drone
+  volumes:
+  - name: cache
+    path: /ephemeral
 
 - name: "Check package: R 4.1"
   pull: never
   image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.1:cran-latest
   commands:
   - R -s -e 'devtools::install_deps(upgrade = '"'"'always'"'"')'
-  - R -s -e 'devtools::load_all(); sessioninfo::session_info()'
+  #- R -s -e 'devtools::load_all(); sessioninfo::session_info()'
   - R -s -e 'devtools::check(env_vars = c("NOT_CRAN" = "true"))'
-
-volumes:
-- name: docker.sock
-  host:
-    path: /var/run/docker.sock
-
-trigger:
-  event:
-    exclude:
-    - promote
-
----
-kind: pipeline
-type: docker
-name: coverage
-
-platform:
-  os: linux
-  arch: amd64
-
-steps:
-- name: pull
-  image: omerxx/drone-ecr-auth
-  commands:
-  - $(aws ecr get-login --no-include-email --region us-east-1)
-  - docker pull 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.1:latest
-  volumes:
-  - name: docker.sock
-    path: /var/run/docker.sock
-
-
-- name: Code coverage
-  pull: never
-  image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.1:latest
-  commands:
-  - R -s -e 'devtools::install_deps(upgrade = '"'"'never'"'"')'
-  - R -s -e 'covr::codecov()'
   environment:
-    CODECOV_TOKEN:
-      from_secret: CODECOV_TOKEN
-    NOT_CRAN: true
+    USER: drone
+  volumes:
+  - name: cache
+    path: /ephemeral
 
 volumes:
 - name: docker.sock
@@ -169,13 +55,10 @@ trigger:
     exclude:
     - promote
 
-depends_on:
-- mpn:latest
-- cran-latest
 ---
 kind: pipeline
 type: docker
-name: release
+name: pmplots-release
 
 platform:
   os: linux
@@ -186,21 +69,20 @@ steps:
   image: omerxx/drone-ecr-auth
   commands:
   - $(aws ecr get-login --no-include-email --region us-east-1)
-  - docker pull 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.1:latest
+  - docker pull 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.0:latest
   volumes:
   - name: docker.sock
     path: /var/run/docker.sock
 
 - name: Build package
   pull: never
-  image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.1:latest
+  image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.0:latest
   commands:
   - git config --global user.email drone@metrumrg.com
   - git config --global user.name Drony
   - git fetch --tags
+  - R -s -e 'devtools::install_deps(upgrade = '"'"'always'"'"')'
   - R -s -e 'pkgpub::create_tagged_repo(.dir = '"'"'/ephemeral'"'"')'
-  environment:
-    NOT_CRAN: true
   volumes:
   - name: cache
     path: /ephemeral
@@ -241,6 +123,4 @@ trigger:
   - tag
 
 depends_on:
-- mpn:latest
-- mpn:oldest
 - cran-latest

--- a/.drone.yml
+++ b/.drone.yml
@@ -21,7 +21,7 @@ steps:
   pull: never
   image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.0:cran-latest
   commands:
-  - R -s -e 'devtools::install_deps(upgrade = '"'"'always'"'"')'
+  - R -s -e 'devtools::install_deps(upgrade = '"'"'always'"'"', dependencies=TRUE)'
   #- R -s -e 'devtools::load_all(); sessioninfo::session_info()'
   - R -s -e 'devtools::check(env_vars = c("NOT_CRAN" = "true"))'
   environment:
@@ -34,7 +34,7 @@ steps:
   pull: never
   image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.1:cran-latest
   commands:
-  - R -s -e 'devtools::install_deps(upgrade = '"'"'always'"'"')'
+  - R -s -e 'devtools::install_deps(upgrade = '"'"'always'"'"', dependencies=TRUE)'
   #- R -s -e 'devtools::load_all(); sessioninfo::session_info()'
   - R -s -e 'devtools::check(env_vars = c("NOT_CRAN" = "true"))'
   environment:
@@ -81,7 +81,7 @@ steps:
   - git config --global user.email drone@metrumrg.com
   - git config --global user.name Drony
   - git fetch --tags
-  - R -s -e 'devtools::install_deps(upgrade = '"'"'always'"'"')'
+  - R -s -e 'devtools::install_deps(upgrade = '"'"'always'"'"', dependencies=TRUE)'
   - R -s -e 'pkgpub::create_tagged_repo(.dir = '"'"'/ephemeral'"'"')'
   volumes:
   - name: cache

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,13 +15,13 @@ BugReports: https://github.com/metrumresearchgroup/pmplots/issues
 Encoding: UTF-8
 Language: en-US
 Imports: 
-  dplyr (>= 0.7.2),
-  rlang (>= 0.1.2),
-  glue, 
+  dplyr (>= 1.0.7),
+  rlang (>= 0.4.12),
+  glue (>= 1.5.0), 
   assertthat, 
-  tidyr, 
-  purrr,
-  forcats
+  tidyr (>= 1.1.4), 
+  purrr (>= 0.3.4),
+  forcats (>= 0.5.1)
 VignetteBuilder: knitr
 Suggests: 
   testthat,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,9 +23,18 @@ Imports:
   purrr,
   forcats
 VignetteBuilder: knitr
-Suggests: testthat, GGally, latex2exp, knitr, cowplot, yaml, miniUI, shiny, rmarkdown
+Suggests: 
+  testthat,
+  GGally, 
+  latex2exp, 
+  patchwork, 
+  knitr, 
+  yaml, 
+  miniUI, 
+  shiny, 
+  rmarkdown
 Depends: ggplot2 (>= 3.0.0)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Roxygen: list(markdown = TRUE)
 Collate: 
     'Aaaa.R'

--- a/R/utils.R
+++ b/R/utils.R
@@ -433,29 +433,31 @@ parse_eval <- function(x) {
   eval(parse(text = x),envir=parent.frame(2))
 }
 
-##' Arrange a list of plots in a grid
-##'
-##' @param x a list of plots
-##' @param ncol passed to \code{\link[cowplot]{plot_grid}}
-##' @param ... passed to \code{\link[cowplot]{plot_grid}}
-##'
-##' @details
-##' The cowplot package must be installed to use this function.
-##'
-##' @examples
-##'
-##' data <- pmplots_data_obs()
-##'
-##' plot <- wres_cont(data, x = c("WT", "ALB"))
-##'
-##' pm_grid(plot)
-##'
-##' @export
-pm_grid <- function(x, ..., ncol=2) {
-  if(!requireNamespace("cowplot")) {
-    stop("Please install the cowplot package to use this function.")
+#' Arrange a list of plots in a grid
+#'
+#' This is a ligth wrapper around [patchwork::wrap_plots()].
+#'
+#' @param x A list of plots.
+#' @param ncol Passed to [patchwork::wrap_plots()].
+#' @param ... Passed to [patchwork::wrap_plots()].
+#'
+#' @details
+#' The patchwork package must be installed to use this function.
+#'
+#' @examples
+#' data <- pmplots_data_obs()
+#'
+#' plot <- wres_cont(data, x = c("WT", "ALB"))
+#'
+#' pm_grid(plot)
+#'
+#' @md
+#' @export
+pm_grid <- function(x, ..., ncol = 2) {
+  if(!requireNamespace("patchwork")) {
+    stop("Please install the patchwork package to use this function.")
   }
-  cowplot::plot_grid(plotlist=x, ..., ncol = ncol)
+  patchwork::wrap_plots(x, ncol = ncol, ...)
 }
 
 chunk_by_id <- function(data,nchunk,id_col="ID",mark=NULL) {

--- a/man/pm_grid.Rd
+++ b/man/pm_grid.Rd
@@ -7,20 +7,19 @@
 pm_grid(x, ..., ncol = 2)
 }
 \arguments{
-\item{x}{a list of plots}
+\item{x}{A list of plots.}
 
-\item{...}{passed to \code{\link[cowplot]{plot_grid}}}
+\item{...}{Passed to \code{\link[patchwork:wrap_plots]{patchwork::wrap_plots()}}.}
 
-\item{ncol}{passed to \code{\link[cowplot]{plot_grid}}}
+\item{ncol}{Passed to \code{\link[patchwork:wrap_plots]{patchwork::wrap_plots()}}.}
 }
 \description{
-Arrange a list of plots in a grid
+This is a ligth wrapper around \code{\link[patchwork:wrap_plots]{patchwork::wrap_plots()}}.
 }
 \details{
-The cowplot package must be installed to use this function.
+The patchwork package must be installed to use this function.
 }
 \examples{
-
 data <- pmplots_data_obs()
 
 plot <- wres_cont(data, x = c("WT", "ALB"))


### PR DESCRIPTION
# Summary
- `pm_grid()` now uses `patchwork::wrap_plots()`
- This is now a lighter than light wrapper; maintained for historical interest
- Also bumped dependencies

``` r
library(pmplots)
#> Loading required package: ggplot2
data <- pmplots_data_obs()
p1 <- dv_pred(data)
p2 <- dv_pred(data, alpha = 0.1)

pm_grid(list(p1, p2))
#> Loading required namespace: patchwork
#> `geom_smooth()` using formula 'y ~ x'
#> `geom_smooth()` using formula 'y ~ x'
```

![](https://i.imgur.com/mzQTKZd.png)

<sup>Created on 2022-03-04 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>