### PR TITLE
Release/0.3.7

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pmplots
 Type: Package
 Title: Plots for Pharmacometrics
-Version: 0.3.6.9000
+Version: 0.3.6.9001
 Authors@R: c(
        person("Kyle T", "Baron", "", "kyleb@metrumrg.com", c("aut", "cre")),
        person("Metrum Research Group", role =  c("cph"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pmplots
 Type: Package
 Title: Plots for Pharmacometrics
-Version: 0.3.6
+Version: 0.3.6.9000
 Authors@R: c(
        person("Kyle T", "Baron", "", "kyleb@metrumrg.com", c("aut", "cre")),
        person("Metrum Research Group", role =  c("cph"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Suggests:
   shiny, 
   rmarkdown
 Depends: ggplot2 (>= 3.4.0)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
 Collate: 
     'Aaaa.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pmplots
 Type: Package
 Title: Plots for Pharmacometrics
-Version: 0.3.6.9001
+Version: 0.3.7
 Authors@R: c(
        person("Kyle T", "Baron", "", "kyleb@metrumrg.com", c("aut", "cre")),
        person("Metrum Research Group", role =  c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # pmplots (development version)
 
+## Bugs fixed
+
+- Fix bug where density line was not being drawn by default over npde and 
+  cwres histograms; the bug came about from incomplete transition to 
+  changes introduced in `ggplot2` v3.4.0 (#74, #75).
+
 # pmplots 0.3.6
 
 - Update plotting code to work with new `ggplot2` behavior introduced 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# pmplots (development version)
+# pmplots 0.3.7
 
 ## Bugs fixed
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# pmplots (development version)
+
 # pmplots 0.3.6
 
 - Update plotting code to work with new `ggplot2` behavior introduced 

--- a/R/hist.R
+++ b/R/hist.R
@@ -1,21 +1,21 @@
 ##' Generate a histogram plot
 ##'
-##' \code{cont_hist_list} is a vectorized version
-##' of \code{cont_hist}.  \code{pm_histogram} is a generic histogram
+##' `cont_hist_list` is a vectorized version
+##' of `cont_hist`.  `pm_histogram` is a generic histogram
 ##' function that is called by other functions in pmplots.
 ##'
-##' @param df the data frame containing plotting data
-##' @param x the x column for \code{geom_histogram}
+##' @param df the data frame containing plotting data.
+##' @param x the x column for [ggplot2::geom_histogram()].
 ##' @param y what to use for the y-axis on the histogram; can be
-##' \code{"count"} or \code{"density"}
-##' @param add_density if \code{TRUE}, a normal density line will
-##' be plotted over the histogram using \code{\link{add_density}}
-##' @param xs a list of information for the x axis
-##' @param fill a character value passed to \code{geom_histogram}
-##' @param col a character value passed to \code{geom_histogram}
-##' @param alpha a numeric value passed to \code{geom_histogram}
-##' @param add_layers extra layers will be added only if \code{TRUE}
-##' @param ... passed to \code{geom_histogram} and \code{add_density}
+##' `"count"` or `"density"`.
+##' @param add_density if `TRUE`, a normal density line will
+##' be plotted over the histogram using [add_density()].
+##' @param xs a list of information for the x axis.
+##' @param fill a character value passed to [ggplot2::geom_histogram()].
+##' @param col a character value passed to [ggplot2::geom_histogram()].
+##' @param alpha a numeric value passed to [ggplot2::geom_histogram()].
+##' @param add_layers extra layers will be added only if `TRUE`.
+##' @param ... passed to [ggplot2::geom_histogram()] and [add_density()].
 ##'
 ##'
 ##' @examples
@@ -25,7 +25,7 @@
 ##' cont_hist(data, x = "WT//Weight (kg)")
 ##'
 ##' @return A single plot.
-##'
+##' @md
 ##' @export
 cont_hist <- function(df, x, xs = defx(),
                       y = "count",

--- a/R/res_hist.R
+++ b/R/res_hist.R
@@ -1,11 +1,11 @@
 ##' Histograms of residuals or NPDE
 ##'
-##' @param df data frame to plot
-##' @param ... passed to \code{\link{cont_hist}}
-##' @param x character name for x-axis data
-##' @param xs see \code{\link{defx}}
+##' @param df data frame to plot.
+##' @param ... passed to [cont_hist()]
+##' @param x character name for x-axis data.
+##' @param xs see [defx()].
 ##' @param y what to use for the y-axis on the histogram; can be
-##' \code{"..count.."} or \code{"..density.."}
+##' "count"` or `"density"`.
 ##'
 ##' @examples
 ##' df <- pmplots_data_obs()
@@ -13,6 +13,8 @@
 ##' cwres_hist(df)
 ##'
 ##' @return A single plot.
+##'
+##' @md
 ##'
 ##' @export
 res_hist <- function(df, ...,
@@ -25,7 +27,7 @@ res_hist <- function(df, ...,
 ##' @rdname res_hist
 wres_hist <- function(df, ...,
                       x = pm_axis_wres(),
-                      y = "..density..") {
+                      y = "density") {
   res_hist(df, x = x, y = y, ...)
 }
 

--- a/inst/validation/pmplots-stories.yaml
+++ b/inst/validation/pmplots-stories.yaml
@@ -190,6 +190,7 @@ PMP-S023:
   - PMP-TEST-040
   - PMP-TEST-041
   - PMP-TEST-074
+  - PMP-TEST-089
 PMP-S024:
   name: List plots
   description: As a user, I want to create list plots.

--- a/man/cont_hist.Rd
+++ b/man/cont_hist.Rd
@@ -26,27 +26,27 @@ pm_histogram(
 )
 }
 \arguments{
-\item{df}{the data frame containing plotting data}
+\item{df}{the data frame containing plotting data.}
 
-\item{x}{the x column for \code{geom_histogram}}
+\item{x}{the x column for \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}}.}
 
-\item{xs}{a list of information for the x axis}
+\item{xs}{a list of information for the x axis.}
 
 \item{y}{what to use for the y-axis on the histogram; can be
-\code{"count"} or \code{"density"}}
+\code{"count"} or \code{"density"}.}
 
 \item{add_density}{if \code{TRUE}, a normal density line will
-be plotted over the histogram using \code{\link{add_density}}}
+be plotted over the histogram using \code{\link[=add_density]{add_density()}}.}
 
-\item{add_layers}{extra layers will be added only if \code{TRUE}}
+\item{add_layers}{extra layers will be added only if \code{TRUE}.}
 
-\item{...}{passed to \code{geom_histogram} and \code{add_density}}
+\item{...}{passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} and \code{\link[=add_density]{add_density()}}.}
 
-\item{col}{a character value passed to \code{geom_histogram}}
+\item{col}{a character value passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}}.}
 
-\item{fill}{a character value passed to \code{geom_histogram}}
+\item{fill}{a character value passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}}.}
 
-\item{alpha}{a numeric value passed to \code{geom_histogram}}
+\item{alpha}{a numeric value passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}}.}
 }
 \value{
 A single plot.

--- a/man/res_hist.Rd
+++ b/man/res_hist.Rd
@@ -10,7 +10,7 @@
 \usage{
 res_hist(df, ..., x = pm_axis_res(), xs = defx())
 
-wres_hist(df, ..., x = pm_axis_wres(), y = "..density..")
+wres_hist(df, ..., x = pm_axis_wres(), y = "density")
 
 cwres_hist(df, ..., x = pm_axis_cwres())
 
@@ -19,16 +19,16 @@ cwresi_hist(df, x = pm_axis_cwresi(), ...)
 npde_hist(df, ..., x = pm_axis("npde"))
 }
 \arguments{
-\item{df}{data frame to plot}
+\item{df}{data frame to plot.}
 
-\item{...}{passed to \code{\link{cont_hist}}}
+\item{...}{passed to \code{\link[=cont_hist]{cont_hist()}}}
 
-\item{x}{character name for x-axis data}
+\item{x}{character name for x-axis data.}
 
-\item{xs}{see \code{\link{defx}}}
+\item{xs}{see \code{\link[=defx]{defx()}}.}
 
 \item{y}{what to use for the y-axis on the histogram; can be
-\code{"..count.."} or \code{"..density.."}}
+"count"\code{or}"density"`.}
 }
 \value{
 A single plot.

--- a/tests/testthat/test-pm.R
+++ b/tests/testthat/test-pm.R
@@ -180,6 +180,22 @@ test_that("res hist [PMP-TEST-041]", {
 })
 
 
+test_that("optional density plot over histogram [PMP-TEST-089]", {
+  # issue 74
+  x <- npde_hist(df)
+  expect_is(x, "gg")
+  expect_length(x$layers, 2)
+
+  y <- npde_hist(df, add_density = FALSE)
+  expect_length(y$layers, 1)
+
+  z <- cont_hist(df, x = "NPDE", add_density = TRUE)
+  expect_length(z$layers, 2)
+
+  w <- cont_hist(df, x = "WT", add_density = FALSE)
+  expect_length(w$layers, 1)
+})
+
 test_that("eta pairs [PMP-TEST-042]", {
   p <- eta_pairs(df, c("ETA1//ETA-CL", "ETA2//ETA-V2"))
   expect_is(p,"ggmatrix")


### PR DESCRIPTION
# pmplots 0.3.7

## Bugs fixed

- Fix bug where density line was not being drawn by default over npde and 
  cwres histograms; the bug came about from incomplete transition to 
  changes introduced in `ggplot2` v3.4.0 (#74, #75).
