### PR TITLE
Pm grid

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -500,7 +500,7 @@ pm_grid <- function(x, ..., ncol = 2, tag_levels = NULL) {
   require_patchwork()
   x <- patchwork::wrap_plots(x, ncol = ncol, ...)
   if(!is.null(tag_levels)) {
-    x <- patchwork::plot_annotation(x, tag_levels = tag_levels)
+    x <- x + patchwork::plot_annotation(tag_levels = tag_levels)
   }
   x
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -473,11 +473,14 @@ parse_eval <- function(x) {
 
 #' Arrange a list of plots in a grid
 #'
-#' This is a light wrapper around [patchwork::wrap_plots()].
+#' This is a light wrapper around [patchwork::wrap_plots()] to
+#' arrange the plots and [patchwork::plot_annotation()] to
+#' optionally tag levels in the grid of plots.
 #'
-#' @param x A list of plots.
-#' @param ncol Passed to [patchwork::wrap_plots()].
-#' @param ... Passed to [patchwork::wrap_plots()].
+#' @param x a list of plots.
+#' @param ncol passed to [patchwork::wrap_plots()].
+#' @param tag_levels passed to [patchwork::plot_annotation()].
+#' @param ... passed to [patchwork::wrap_plots()].
 #'
 #' @details
 #' The patchwork package must be installed to use this function.
@@ -489,11 +492,17 @@ parse_eval <- function(x) {
 #'
 #' pm_grid(plot)
 #'
+#' pm_grid(plot, tag_levels = "a")
+#'
 #' @md
 #' @export
-pm_grid <- function(x, ..., ncol = 2) {
+pm_grid <- function(x, ..., ncol = 2, tag_levels = NULL) {
   require_patchwork()
-  patchwork::wrap_plots(x, ncol = ncol, ...)
+  x <- patchwork::wrap_plots(x, ncol = ncol, ...)
+  if(!is.null(tag_levels)) {
+    x <- patchwork::plot_annotation(x, tag_levels = tag_levels)
+  }
+  x
 }
 
 #' Chunk a data frame

--- a/R/utils.R
+++ b/R/utils.R
@@ -496,7 +496,7 @@ parse_eval <- function(x) {
 #'
 #' @md
 #' @export
-pm_grid <- function(x, ..., ncol = 2, tag_levels = NULL) {
+pm_grid <- function(x, ncol = 2, tag_levels = NULL, ...) {
   require_patchwork()
   x <- patchwork::wrap_plots(x, ncol = ncol, ...)
   if(!is.null(tag_levels)) {

--- a/man/pm_grid.Rd
+++ b/man/pm_grid.Rd
@@ -4,17 +4,21 @@
 \alias{pm_grid}
 \title{Arrange a list of plots in a grid}
 \usage{
-pm_grid(x, ..., ncol = 2)
+pm_grid(x, ..., ncol = 2, tag_levels = NULL)
 }
 \arguments{
-\item{x}{A list of plots.}
+\item{x}{a list of plots.}
 
-\item{...}{Passed to \code{\link[patchwork:wrap_plots]{patchwork::wrap_plots()}}.}
+\item{...}{passed to \code{\link[patchwork:wrap_plots]{patchwork::wrap_plots()}}.}
 
-\item{ncol}{Passed to \code{\link[patchwork:wrap_plots]{patchwork::wrap_plots()}}.}
+\item{ncol}{passed to \code{\link[patchwork:wrap_plots]{patchwork::wrap_plots()}}.}
+
+\item{tag_levels}{passed to \code{\link[patchwork:plot_annotation]{patchwork::plot_annotation()}}.}
 }
 \description{
-This is a light wrapper around \code{\link[patchwork:wrap_plots]{patchwork::wrap_plots()}}.
+This is a light wrapper around \code{\link[patchwork:wrap_plots]{patchwork::wrap_plots()}} to
+arrange the plots and \code{\link[patchwork:plot_annotation]{patchwork::plot_annotation()}} to
+optionally tag levels in the grid of plots.
 }
 \details{
 The patchwork package must be installed to use this function.
@@ -25,5 +29,7 @@ data <- pmplots_data_obs()
 plot <- wres_cont(data, x = c("WT", "ALB"))
 
 pm_grid(plot)
+
+pm_grid(plot, tag_levels = "a")
 
 }

--- a/man/pm_grid.Rd
+++ b/man/pm_grid.Rd
@@ -4,16 +4,16 @@
 \alias{pm_grid}
 \title{Arrange a list of plots in a grid}
 \usage{
-pm_grid(x, ..., ncol = 2, tag_levels = NULL)
+pm_grid(x, ncol = 2, tag_levels = NULL, ...)
 }
 \arguments{
 \item{x}{a list of plots.}
 
-\item{...}{passed to \code{\link[patchwork:wrap_plots]{patchwork::wrap_plots()}}.}
-
 \item{ncol}{passed to \code{\link[patchwork:wrap_plots]{patchwork::wrap_plots()}}.}
 
 \item{tag_levels}{passed to \code{\link[patchwork:plot_annotation]{patchwork::plot_annotation()}}.}
+
+\item{...}{passed to \code{\link[patchwork:wrap_plots]{patchwork::wrap_plots()}}.}
 }
 \description{
 This is a light wrapper around \code{\link[patchwork:wrap_plots]{patchwork::wrap_plots()}} to

--- a/tests/testthat/test-list_plot.R
+++ b/tests/testthat/test-list_plot.R
@@ -11,6 +11,11 @@ test_that("pm_grid [PMP-TEST-015]", {
   expect_is(pm_grid(list(p,p)), "gg")
 })
 
+test_that("pm_grid tag levels", {
+  a <- pm_grid(list(p,p), tag_levels = "i")
+  expect_equal(a$patches$annotation$tag_levels, "i")
+})
+
 x <- c("WT", "CRCL", "ALB")
 y <- c("SCR", "AAG")
 


### PR DESCRIPTION
# Summary

This PR is an extension of #77, where we created panels of plots and potentially annotated them with `tag_levels`.  This lets the user to pass `tag_levels` to `pm_grid()` to tag levels after arranging. 

This PR also shuffles the arguments for `pm_grid()`; I don't believe this will change current behavior (?) but thought it would be safest to push `...` to the back. 

