### PR TITLE
Fix compatibility with ggplot2 3.5.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Suggests:
   testthat,
   GGally, 
   latex2exp, 
-  patchwork, 
+  patchwork (>= 1.2.0),
   knitr, 
   yaml, 
   miniUI, 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Suggests:
   shiny, 
   rmarkdown
 Depends: ggplot2 (>= 3.4.0)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Roxygen: list(markdown = TRUE)
 Collate: 
     'Aaaa.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Suggests:
   miniUI, 
   shiny, 
   rmarkdown
-Depends: ggplot2 (>= 3.4.0)
+Depends: ggplot2 (>= 3.5.0)
 RoxygenNote: 7.3.1
 Roxygen: list(markdown = TRUE)
 Collate: 

--- a/R/cont.R
+++ b/R/cont.R
@@ -116,6 +116,9 @@ y_time <- function(df,
   inx <- xs
   iny <- ys
 
+  xs <- remap_trans_arg(xs)
+  ys <- remap_trans_arg(ys)
+
   xs <- update_list(defx(),xs)
   ys <- update_list(defy(), ys)
 
@@ -127,7 +130,7 @@ y_time <- function(df,
   }
 
   if(log) {
-    ys$trans <- "log"
+    ys$transform <- "log"
     ys$breaks <- logbr3()
   }
 

--- a/R/dv_pred.R
+++ b/R/dv_pred.R
@@ -70,6 +70,9 @@ dv_pred <- function(df, x = pm_axis_pred(), y = pm_axis_dv(),
   inx <- xs
   iny <- ys
 
+  xs <- remap_trans_arg(xs)
+  ys <- remap_trans_arg(ys)
+
   xs <- update_list(defx(), xs)
   ys <- update_list(defy(), ys)
 
@@ -77,8 +80,8 @@ dv_pred <- function(df, x = pm_axis_pred(), y = pm_axis_dv(),
   y <- y[1]
 
   if(loglog) {
-    xs$trans <- "log10"
-    ys$trans <- "log10"
+    xs$transform <- "log10"
+    ys$transform <- "log10"
     logbr <- match.arg(logbr)
     if(logbr == "half") {
       log_breaks <- logbr3()
@@ -91,7 +94,7 @@ dv_pred <- function(df, x = pm_axis_pred(), y = pm_axis_dv(),
     }
   }
 
-  if(xs$trans %in% c("log", "log10")) {
+  if(xs$transform %in% c("log", "log10")) {
     xkp <- df[,x] > 0
     df <- dplyr::filter(df, xkp)
     if(.miss("breaks", inx)) {
@@ -99,7 +102,7 @@ dv_pred <- function(df, x = pm_axis_pred(), y = pm_axis_dv(),
     }
   }
 
-  if(ys$trans %in% c("log", "log10")) {
+  if(ys$transform %in% c("log", "log10")) {
     ykp <- df[,y] > 0
     df <- dplyr::filter(df, ykp)
     if(.miss("breaks", iny)) {

--- a/R/dv_time.R
+++ b/R/dv_time.R
@@ -65,6 +65,9 @@ dv_time <- function(df, x=pm_axis_time(), y=pm_axis_dv(),
   inx <- xs
   iny <- ys
 
+  xs <- remap_trans_arg(xs)
+  ys <- remap_trans_arg(ys)
+
   xs <- update_list(defx(),xs)
   ys <- update_list(defy(),ys)
 
@@ -77,10 +80,10 @@ dv_time <- function(df, x=pm_axis_time(), y=pm_axis_dv(),
   }
 
   if(log) {
-    ys$trans <- "log"
+    ys$transform <- "log"
   }
 
-  if(ys$trans %in% c("log", "log10")) {
+  if(ys$transform %in% c("log", "log10")) {
     ykp <- df[,y] > 0
     df <- dplyr::filter(df,ykp)
     if(.miss("breaks", iny)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -100,12 +100,17 @@ logbr3 <- function() {
 ##'
 ##' @param breaks passed to scale function
 ##' @param limits passed to scale function
-##' @param trans passed to scale function
+##' @param transform passed to scale function
+##' @param trans deprecated; use `transform` argument instead.
 ##' @param ... passed to scale function
 ##'
 ##' @export
-pm_log <- function(breaks = NULL, limits=NULL, trans = "log10", ...) {
-  ans <- list(trans = trans,...)
+pm_log <- function(breaks = NULL, limits=NULL, transform = "log10", ..., trans = deprecated()) {
+  ans <- list(transform = transform, ...)
+  if (is_present(trans)) {
+    deprecate_warn("0.5.0", "pm_log(trans)", "pm_log(transform)")
+    ans[["transform"]] <- trans
+  }
   ans[["breaks"]] <- breaks
   ans[["limits"]] <- limits
   ans
@@ -132,18 +137,24 @@ pm_ident <- function(breaks, limits = range(breaks), ...) {
 ##' this default as a base.
 ##'
 ##' @param ... arguments for \code{scale_x_continuous}
+##' @param trans deprecated; use `transform` argument instead.
 ##'
 ##' @details
 ##' In the named list, the name is the argument name and the value
 ##' is the argument value.
 ##'
 ##' @examples
-##' defx(trans="log")
+##' defx(transform="log")
 ##'
 ##' @export
-defx <- function(...) {
+defx <- function(..., trans = deprecated()) {
   x0 <- list(...)
+  if (is_present(trans)) {
+    deprecate_warn("0.5.0", "defx(trans)", "defx(transform)")
+    x0[["transform"]] <- trans
+  }
   x <- as.list(formals(ggplot2::scale_x_continuous))
+  x[["trans"]] <- NULL
   x <- merge.list(x,x0)
   x$oob <-  NULL
   x
@@ -158,14 +169,20 @@ defx <- function(...) {
 ##' this default as a base.
 ##'
 ##' @param ... arguments for \code{scale_y_continuous}
+##' @param trans deprecated; use `transform` argument instead.
 ##'
 ##' @examples
-##' defy(trans="log")
+##' defy(transform="log")
 ##'
 ##' @export
-defy <- function(...) {
+defy <- function(..., trans = deprecated()) {
   x0 <- list(...)
+  if (is_present(trans)) {
+    deprecate_warn("0.5.0", "defy(trans)", "defy(transform)")
+    x0[["transform"]] <- trans
+  }
   x <- as.list(formals(ggplot2::scale_y_continuous))
+  x[["trans"]] <- NULL
   x <- merge.list(x,x0)
   x$oob <-  NULL
   x
@@ -207,7 +224,7 @@ defcx <- function(...) {
 ##'
 ##' @export
 log_scale <- function(breaks=NULL,...) {
-  ans <- list(trans="log10",...)
+  ans <- list(transform="log10",...)
   ans[["breaks"]] <- breaks
   ans
 }
@@ -364,6 +381,19 @@ update_list <- function(left, right) {
   common <- intersect(names(left), names(right))
   left[common] <-  right[common]
   left
+}
+
+remap_trans_arg <- function(args, user_env = rlang::caller_env(2)) {
+  # ggplot2 3.5.0 deprecated `trans` in favor of `transform`.
+  if ("trans" %in% names(args)) {
+    deprecate_warn(
+      "0.5.0", I("`trans` argument"), I("`transform` argument"),
+      user_env = user_env
+    )
+    args[["transform"]] <- args[["trans"]]
+    args[["trans"]] <- NULL
+  }
+  return(args)
 }
 
 ##' Rotate axis text

--- a/R/utils.R
+++ b/R/utils.R
@@ -193,7 +193,7 @@ defcx <- function(...) {
   x0 <- list(...)
   x <- as.list(formals(ggplot2::scale_x_discrete))
   x <- merge.list(x,x0)
-  x[[1]] <- NULL
+  x[["..."]] <- NULL
   x
 }
 

--- a/inst/examples/pmplots_complete.Rmd
+++ b/inst/examples/pmplots_complete.Rmd
@@ -669,7 +669,7 @@ wrap_cont_time(df, y = y, use_labels=TRUE)
 ## Modify x-axis
 
 ```{r}
-a <- list(trans="log", breaks = logbr3())
+a <- list(transform="log", breaks = logbr3())
 
 dv_time(df, xs=a)
 ```

--- a/inst/examples/pmplots_complete.md
+++ b/inst/examples/pmplots_complete.md
@@ -880,7 +880,7 @@ wrap_cont_time(df, y = y, use_labels=TRUE)
 ## Modify x-axis
 
 ``` r
-a <- list(trans="log", breaks = logbr3())
+a <- list(transform="log", breaks = logbr3())
 
 dv_time(df, xs=a)
 ```

--- a/inst/examples/pmplots_complete_validation.Rmd
+++ b/inst/examples/pmplots_complete_validation.Rmd
@@ -669,7 +669,7 @@ wrap_cont_time(df, y = y, use_labels=TRUE)
 ### Modify x-axis
 
 ```{r}
-a <- list(trans="log", breaks = logbr3())
+a <- list(transform="log", breaks = logbr3())
 
 dv_time(df, xs=a)
 ```

--- a/man/defx.Rd
+++ b/man/defx.Rd
@@ -4,10 +4,12 @@
 \alias{defx}
 \title{Default setting for x-axis scale}
 \usage{
-defx(...)
+defx(..., trans = deprecated())
 }
 \arguments{
 \item{...}{arguments for \code{scale_x_continuous}}
+
+\item{trans}{deprecated; use \code{transform} argument instead.}
 }
 \description{
 A named list of the formal arguments for \code{scale_x_continuous}.  This
@@ -21,6 +23,6 @@ In the named list, the name is the argument name and the value
 is the argument value.
 }
 \examples{
-defx(trans="log")
+defx(transform="log")
 
 }

--- a/man/defy.Rd
+++ b/man/defy.Rd
@@ -4,10 +4,12 @@
 \alias{defy}
 \title{Default setting for continuous y-axis scale}
 \usage{
-defy(...)
+defy(..., trans = deprecated())
 }
 \arguments{
 \item{...}{arguments for \code{scale_y_continuous}}
+
+\item{trans}{deprecated; use \code{transform} argument instead.}
 }
 \description{
 A named list of the formal arguments for \code{scale_y_continuous}.  This
@@ -17,6 +19,6 @@ create your own named list for arguments you want to update, using
 this default as a base.
 }
 \examples{
-defy(trans="log")
+defy(transform="log")
 
 }

--- a/man/pm_log.Rd
+++ b/man/pm_log.Rd
@@ -5,7 +5,13 @@
 \alias{pm_ident}
 \title{Identity and log scale helpers}
 \usage{
-pm_log(breaks = NULL, limits = NULL, trans = "log10", ...)
+pm_log(
+  breaks = NULL,
+  limits = NULL,
+  transform = "log10",
+  ...,
+  trans = deprecated()
+)
 
 pm_ident(breaks, limits = range(breaks), ...)
 }
@@ -14,9 +20,11 @@ pm_ident(breaks, limits = range(breaks), ...)
 
 \item{limits}{passed to scale function}
 
-\item{trans}{passed to scale function}
+\item{transform}{passed to scale function}
 
 \item{...}{passed to scale function}
+
+\item{trans}{deprecated; use \code{transform} argument instead.}
 }
 \description{
 Identity and log scale helpers

--- a/vignettes/complete.Rmd
+++ b/vignettes/complete.Rmd
@@ -680,7 +680,7 @@ wrap_cont_time(df, y = y, use_labels=TRUE)
 ## Modify x-axis
 
 ```{r}
-a <- list(trans="log", breaks = logbr3())
+a <- list(transform="log", breaks = logbr3())
 
 dv_time(df, xs=a)
 ```

--- a/vignettes/customize.Rmd
+++ b/vignettes/customize.Rmd
@@ -95,7 +95,7 @@ dv_time(data, xby = 30)
 You can put the y-axis on log scale
 
 ```{r}
-dv_time(data, ys = list(trans = "log10"))
+dv_time(data, ys = list(transform = "log10"))
 ```
 
 Again note there is a `log` argument to this function that lets us do this 
@@ -111,7 +111,7 @@ in your plot.
 
 Specifically not that you should not do this
 ```{r}
-dv_time(data) + scale_y_continuous(trans = "log10")
+dv_time(data) + scale_y_continuous(transform = "log10")
 ```
 
 This will result in a warning and clobber the scale that pmplots set. Always


### PR DESCRIPTION
Two changes in ggplot2 3.5.0 trigger `pmplots` failures:

 * the `name` argument in scale functions has been re-positioned ([commit](https://github.com/tidyverse/ggplot2/commit/0f9fb64505bdb404081bdbfa09b34aa7213f699f))

 * the `trans` argument in scale functions has been renamed to `transform` ([commit](https://github.com/tidyverse/ggplot2/commit/000a9392ed3bf9df813baa442b777edac0b044f9))

This series fixes those problems.  (See the commit messages for more details.)

To simplify the `trans` fix, the **minimum ggplot2 version is increased to 3.5.0**.  There's precedence for that approach with the pmplots 0.3.6 release (described [here](https://github.com/metrumresearchgroup/pmplots/pull/71#issuecomment-1325323884)).  @kylebaron, please let me know if you think we should try to stay compatible with older ggplot2 versions in this case.

In addition the low-level tests I added, I did the following and didn't notice any issues: 1) interactively tested many of these functions and 2) rendered the site and scrolled through the various vignettes.

Closes #84.
