### PR TITLE
Filter with logical vector rather than data frame

### DIFF
--- a/R/dv_pred.R
+++ b/R/dv_pred.R
@@ -92,7 +92,7 @@ dv_pred <- function(df, x = pm_axis_pred(), y = pm_axis_dv(),
   }
 
   if(xs$trans %in% c("log", "log10")) {
-    xkp <- df[,x] > 0
+    xkp <- df[[x]] > 0
     df <- dplyr::filter(df, xkp)
     if(.miss("breaks", inx)) {
       xs$breaks <- log_breaks
@@ -100,7 +100,7 @@ dv_pred <- function(df, x = pm_axis_pred(), y = pm_axis_dv(),
   }
 
   if(ys$trans %in% c("log", "log10")) {
-    ykp <- df[,y] > 0
+    ykp <- df[[y]] > 0
     df <- dplyr::filter(df, ykp)
     if(.miss("breaks", iny)) {
       ys$breaks <- log_breaks


### PR DESCRIPTION
Silences warning that started with `dplyr` 1.1.0. See #87 for example. 