### PR TITLE
Fix wrong y-axis for cwres_covariate

### DIFF
--- a/R/displays.R
+++ b/R/displays.R
@@ -199,7 +199,7 @@ cwres_covariate <- function(df, x, ncol = 2, tag_levels = NULL, byrow = NULL) {
 #' @rdname cwres_covariate
 #' @export
 cwres_covariate_list <- function(df, x) {
-  p  <- diagnostic_display_list(df, x, pm_axis_npde(), cwres_cat, cwres_cont)
+  p  <- diagnostic_display_list(df, x, pm_axis_cwres(), cwres_cat, cwres_cont)
   p <- p[[1]]
   labx <- col_label_col(x)
   names(p) <- labx


### PR DESCRIPTION
`cwres_covariate_list` was using `npde` axis rather than `cwres`. Copy-paste error. See example in #85. 

I think this is failing CI due to ggplot2 updates. Can we merge this and check again?
