### PR TITLE
Remove 'distribution' from y-axis title in npde and cwres qq plots

### DIFF
--- a/R/qq.R
+++ b/R/qq.R
@@ -47,7 +47,7 @@ wres_q <- function(df, x="WRES", xs = defx(), ys=defy(), abline=NULL,
   p <- ggplot(data = df, aes(sample = .data[[x]]))
   p <- p + stat_qq(color=col, alpha=alpha, distribution=qnorm,size=size)
   p <- p + xscale + yscale
-  p <- p + pm_labs(x = "Standard normal quantile", y = paste0(x, " distribution quantile"))
+  p <- p + pm_labs(x = "Standard normal quantile", y = paste0(x, " quantile"))
   if(!is.null(abline)) {
     p <- p + geom_abline(intercept=abline[1], slope=abline[2])
   }


### PR DESCRIPTION
See #90 
Main motivation is to save space to pack plots on a page.  

This was discussed internally with PKPD M&S with agreement to make the change. 