### PR TITLE
Release/0.4.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pmplots
 Type: Package
 Title: Plots for Pharmacometrics
-Version: 0.4.0.9001
+Version: 0.4.1
 Authors@R: c(
        person("Kyle T", "Baron", "", "kyleb@metrumrg.com", c("aut", "cre")),
        person("Metrum Research Group", role =  c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# pmplots (development version)
+# pmplots 0.4.1
 
 # pmplots 0.4.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
 
 ## Bugs fixed
 
-- Fixed a bug where the wrong y-axis title was getting used in [cwres_covariate()]
+- Fixed a bug where the wrong y-axis title was getting used in `cwres_covariate()`
   (#89).
 
 # pmplots 0.4.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 - y-axis for `cwres_q()` and `npde_q()` changed to remove the word "distribution"
   (#92). 
 
-- pmplots now depends on ggplot2 version 3.5.0 or later (#86).
+- pmplots now depends on ggplot2 version 3.5.0 or greater (#86).
 
 - Axis titles for conditional weighted residuals are now abbreviated "CWRES" (#83).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # pmplots 0.4.1
 
+- y-axis for `cwres_q()` and `npde_q()` changed to remove the word "distribution"
+  (#92). 
+
+- pmplots now depends on ggplot2 version 3.5.0 or later (#86).
+
+- Axis titles for conditional weighted residuals are now abbreviated "CWRES" (#83).
+
+## Bugs fixed
+
+- Fixed a bug where the wrong y-axis title was getting used in [cwres_covariate()]
+  (#89).
+
 # pmplots 0.4.0
 
 - Add a series of functions for standardized, paneled displays (#77, #81).


### PR DESCRIPTION
# pmplots 0.4.1

- y-axis for `cwres_q()` and `npde_q()` changed to remove the word "distribution"
  (#92). 

- pmplots now depends on ggplot2 version 3.5.0 or later (#86).

- Axis titles for conditional weighted residuals are now abbreviated "CWRES" (#83).

## Bugs fixed

- Fixed a bug where the wrong y-axis title was getting used in [cwres_covariate()]
  (#89).