### PR TITLE
tests: drop testthat::context calls

### DIFF
--- a/tests/testthat/test-cat.R
+++ b/tests/testthat/test-cat.R
@@ -1,7 +1,5 @@
 library(testthat)
 
-context("test-cat")
-
 df <- pmplots_data_obs()
 id <- pmplots_data_id()
 

--- a/tests/testthat/test-chunk.R
+++ b/tests/testthat/test-chunk.R
@@ -1,7 +1,5 @@
 library(testthat)
 
-context("chunk data sets")
-
 data <- expand.grid(amt = seq(25))
 data$ID  <- seq(nrow(data))
 data2 <- data

--- a/tests/testthat/test-col_label.R
+++ b/tests/testthat/test-col_label.R
@@ -1,7 +1,5 @@
 library(testthat)
 
-context("test-col_label")
-
 test_that("col_label [PMP-TEST-005]", {
 
   x <- col_label("WT // Weight (kg)")

--- a/tests/testthat/test-cont.R
+++ b/tests/testthat/test-cont.R
@@ -1,7 +1,5 @@
 library(testthat)
 
-context("test-cont")
-
 df <- pmplots_data_obs()
 
 test_that("scatter plot IDs [PMP-TEST-007]", {

--- a/tests/testthat/test-data.R
+++ b/tests/testthat/test-data.R
@@ -1,7 +1,5 @@
 library(testthat)
 
-context("test-data")
-
 test_that("data [PMP-TEST-008]", {
   expect_is(pmplots_data(), "data.frame")
   expect_is(pmplots_data_obs(), "data.frame")

--- a/tests/testthat/test-dv-pred-ipred.R
+++ b/tests/testthat/test-dv-pred-ipred.R
@@ -1,8 +1,6 @@
 library(testthat)
 library(pmplots)
 
-context("test-dv-pred-ipred")
-
 df <- pmplots_data_obs()
 
 data <- subset(df, ID <= 9*2)

--- a/tests/testthat/test-layer.R
+++ b/tests/testthat/test-layer.R
@@ -1,8 +1,5 @@
 library(testthat)
 
-context("test-layer")
-
-
 df <- pmplots_data_obs()
 etas <- c("ETA1//ETA-CL", "ETA2//ETA-V2", "ETA3//ETA-KA")
 p <- dv_pred(df)

--- a/tests/testthat/test-list_plot.R
+++ b/tests/testthat/test-list_plot.R
@@ -1,7 +1,5 @@
 library(testthat)
 
-context("test-layer")
-
 df <- pmplots_data_obs()
 etas <- c("ETA1//ETA-CL", "ETA2//ETA-V2", "ETA3//ETA-KA")
 p <- dv_pred(df)

--- a/tests/testthat/test-opts.R
+++ b/tests/testthat/test-opts.R
@@ -1,8 +1,6 @@
 
 library(testthat)
 
-context("test-opts")
-
 def <- pm$defaults
 pm$reset()
 

--- a/tests/testthat/test-pairs.R
+++ b/tests/testthat/test-pairs.R
@@ -1,7 +1,5 @@
 library(testthat)
 
-context("test-pairs")
-
 df <- pmplots_data_obs()
 etas <- c("ETA1//ETA-CL", "ETA2//ETA-V2", "ETA3//ETA-KA")
 

--- a/tests/testthat/test-pm-axis.R
+++ b/tests/testthat/test-pm-axis.R
@@ -1,7 +1,5 @@
 library(testthat)
 
-context("test-pm-axis")
-
 test_that("cwresi plots use cwresi titles [PMP-TEST-033]", {
   call_formals_y <- function(fun) {
     eval(formals(fun)$y)

--- a/tests/testthat/test-pm.R
+++ b/tests/testthat/test-pm.R
@@ -1,7 +1,5 @@
 library(testthat)
 
-context("test-pm")
-
 df <- pmplots_data_obs()
 df[["CWRES"]] <- df[["CWRESI"]]
 etas <- c("ETA1//ETA-CL", "ETA2//ETA-V2", "ETA3//ETA-KA")

--- a/tests/testthat/test-required.R
+++ b/tests/testthat/test-required.R
@@ -1,7 +1,5 @@
 library(testthat)
 
-context("test-required")
-
 df <- dplyr::filter(pmplots_data(),EVID==0)
 
 test_that("Functions fail when col doesn't exist [PMP-TEST-051]", {

--- a/tests/testthat/test-res_time.R
+++ b/tests/testthat/test-res_time.R
@@ -1,7 +1,5 @@
 library(testthat)
 
-context("test-pm")
-
 df <- pmplots_data_obs()
 df[["TAFD"]] <- df[["TIME"]]
 df[["CWRES"]] <- df[["CWRESI"]]

--- a/tests/testthat/test-scatter.R
+++ b/tests/testthat/test-scatter.R
@@ -1,7 +1,5 @@
 library(testthat)
 
-context("test-scatter")
-
 df <- pmplots_data_obs()
 
 test_that("vector inputs for cont_cont [PMP-TEST-055]", {

--- a/tests/testthat/test-split_plot.R
+++ b/tests/testthat/test-split_plot.R
@@ -1,7 +1,5 @@
 library(testthat)
 
-context("test-split_plot")
-
 df <- pmplots_data_obs()
 
 test_that("split_plot succeeds when using numeric split [PMP-TEST-057]", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,6 +1,5 @@
 library(testthat)
 
-context("test-utils")
 data <- pmplots_data_obs()
 p <- dv_time(data)
 

--- a/tests/testthat/test-wrap.R
+++ b/tests/testthat/test-wrap.R
@@ -1,7 +1,5 @@
 library(testthat)
 
-context("test-wrap")
-
 df <- pmplots_data_obs()
 df[["TAFD"]] <- df[["TIME"]]
 df[["CWRES"]] <- df[["CWRESI"]]


### PR DESCRIPTION
Two tests use a context description that references another test: test-res_time.R uses "test-pm" and test-list_plot.R uses "test-layer". Instead of fixing those, drop the context() calls because context() is now deprecated in favor of letting the context be taken from the test file name.