### PR TITLE
Release/0.5.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pmplots
 Type: Package
 Title: Plots for Pharmacometrics
-Version: 0.4.1.9001
+Version: 0.5.0
 Authors@R: c(
        person("Kyle T", "Baron", "", "kyleb@metrumrg.com", c("aut", "cre")),
        person("Metrum Research Group", role =  c("cph"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,6 +4,7 @@ Title: Plots for Pharmacometrics
 Version: 0.5.0
 Authors@R: c(
        person("Kyle T", "Baron", "", "kyleb@metrumrg.com", c("aut", "cre")),
+       person(given = "Kyle", family = "Meyer", role = "ctb"),
        person("Metrum Research Group", role =  c("cph"))
        )
 Maintainer: Kyle Baron <kyleb@metrumrg.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: Plots for Pharmacometrics
 Version: 0.5.0
 Authors@R: c(
        person("Kyle T", "Baron", "", "kyleb@metrumrg.com", c("aut", "cre")),
-       person(given = "Kyle", family = "Meyer", role = "ctb"),
+       person(given = "Kyle", family = "Meyer", role = "ctb", email = "kylem@metrumrg.com"),
        person("Metrum Research Group", role =  c("cph"))
        )
 Maintainer: Kyle Baron <kyleb@metrumrg.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # pmplots 0.5.0
 
-- Multiple `x` and `y` can be now be passed as `list` in addition to 
+- Multiple `x` and `y` can be now be passed as a `list` in addition to 
   character vector (#95). 
 
 - Vectorized plots (returned as a list of plots) are now named according to the 

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,11 +15,11 @@
   allows rotation of specific plots in the list by matching the name exactly 
   or through a regular expression (#96).
 
-- New function `pm_with()`, allowing arrangement of a named list of plots using
+- New function `pm_with()` allows arrangement of a named list of plots using
   `patchwork` syntax (#96). 
 
-- `rot_y()` has been updated with a vertical argument, similar to `rot_x()`
-  (#96). 
+- `rot_y()` has been updated with a `vertical` argument, similar to existing
+  argument in `rot_x()` (#96). 
 
 
 # pmplots 0.4.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,26 @@
 # pmplots 0.5.0
 
+- Multiple `x` and `y` can be now be passed as `list` in addition to 
+  character vector (#95). 
+
+- Vectorized plots (returned as a list of plots) are now named according to the 
+  `x` or `y` data column (#96). 
+
+- New function `rot_xy()` allows rotation of x- or y-axis tick labels for `gg`
+  objects, `patchwork` objects, or lists of `gg` or `patchwork` objects; this 
+  function uses `rot_at()` for processing lists (#96). 
+  
+- New function `rot_at()` allows rotation of x- or y-axis tick labels of `gg`
+  or `patchwork` objects or named lists of these objects; the list method 
+  allows rotation of specific plots in the list by matching the name exactly 
+  or through a regular expression (#96).
+
+- New function `pm_with()`, allowing arrangement of a named list of plots using
+  `patchwork` syntax (#96). 
+
+- `rot_y()` has been updated with a vertical argument, similar to `rot_x()`
+  (#96). 
+
 
 # pmplots 0.4.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
-# pmplots (development version)
+# pmplots 0.5.0
+
 
 # pmplots 0.4.1
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -54,3 +54,7 @@ customizations
 Metrum
 yspec
 README
+parens
+yaml
+unarranged
+


### PR DESCRIPTION

- [x] spelling
- [x] read NEWS
- [x] check version numbers


# pmplots 0.5.0

- Multiple `x` and `y` can be now be passed as a `list` in addition to 
  character vector (#95). 

- Vectorized plots (returned as a list of plots) are now named according to the 
  `x` or `y` data column (#96). 

- New function `rot_xy()` allows rotation of x- or y-axis tick labels for `gg`
  objects, `patchwork` objects, or lists of `gg` or `patchwork` objects; this 
  function uses `rot_at()` for processing lists (#96). 
  
- New function `rot_at()` allows rotation of x- or y-axis tick labels of `gg`
  or `patchwork` objects or named lists of these objects; the list method 
  allows rotation of specific plots in the list by matching the name exactly 
  or through a regular expression (#96).

- New function `pm_with()` allows arrangement of a named list of plots using
  `patchwork` syntax (#96). 

- `rot_y()` has been updated with a `vertical` argument, similar to existing
  argument in `rot_x()` (#96). 


```
scores:
{
  "testing": {
    "check": 1,
    "covr": 0.859
  },
  "documentation": {
    "has_vignettes": 1,
    "has_website": 1,
    "has_news": 1
  },
  "maintenance": {
    "has_maintainer": 1,
    "news_current": 1
  },
  "transparency": {
    "has_source_control": 1,
    "has_bug_reports_url": 1
  }
}
```