### PR TITLE
Refactor eta_covariate to accept integer data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pmplots
 Type: Package
 Title: Plots for Pharmacometrics
-Version: 0.5.0
+Version: 0.5.0.9000
 Authors@R: c(
        person("Kyle T", "Baron", "", "kyleb@metrumrg.com", c("aut", "cre")),
        person(given = "Kyle", family = "Meyer", role = "ctb", email = "kylem@metrumrg.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# pmplots (development version)
+
 # pmplots 0.5.0
 
 - Multiple `x` and `y` can be now be passed as a `list` in addition to 

--- a/R/displays.R
+++ b/R/displays.R
@@ -10,7 +10,7 @@ diagnostic_display_list <- function(df, x, y, fun_cat, fun_cont) {
     out[[i]] <- lapply(seq_along(x), function(ii) {
       col <- col_label(x[[ii]])[[1]]
       require_column(df, col)
-      if(inherits(unlist(df[, col]), c("character", "factor", "logical", "integer"))) {
+      if(.is_discrete(df[[col]])) {
         p <- fun_cat(df, x = x[[ii]], y = y[[i]])
       } else {
         p <- fun_cont(df, x = x[[ii]], y = y[[i]])

--- a/R/utils.R
+++ b/R/utils.R
@@ -38,18 +38,24 @@ supplement_cwres <- function(x) {
 }
 
 require_discrete <- function(df,x) {
-  require_column(df,x)
-  cl <- class(unlist(df[1,x],use.names=FALSE))
-  if(!is.element(cl, c("character", "factor", "logical"))) {
-    .stop("column ", x, " is required to be character, factor, or logical")
+  require_column(df, x)
+  if(!.is_discrete(df[[x]])) {
+    .stop("column ", x, " is required to be character, factor, or logical.")
   }
+}
+
+.is_discrete <- function(x) {
+  inherits(x, c("character", "factor", "logical"))
+}
+
+.is_continuous <- function(x) {
+  inherits(x, c("integer", "numeric"))
 }
 
 require_numeric <- function(df,x) {
   require_column(df,x)
-  cl <- class(unlist(df[1,x],use.names=FALSE))
-  if(!is.element(cl,c("numeric","integer"))) {
-    .stop("column ", x, " is required to be numeric")
+  if(!.is_continuous(df[[x]])) {
+    .stop("column ", x, " is required to be numeric.")
   }
   return(invisible(NULL))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -37,19 +37,19 @@ supplement_cwres <- function(x) {
   return(x)
 }
 
-require_discrete <- function(df,x) {
-  require_column(df, x)
-  if(!.is_discrete(df[[x]])) {
-    .stop("column ", x, " is required to be character, factor, or logical.")
-  }
-}
-
 .is_discrete <- function(x) {
   inherits(x, c("character", "factor", "logical"))
 }
 
 .is_continuous <- function(x) {
   inherits(x, c("integer", "numeric"))
+}
+
+require_discrete <- function(df,x) {
+  require_column(df, x)
+  if(!.is_discrete(df[[x]])) {
+    .stop("column ", x, " is required to be character, factor, or logical.")
+  }
 }
 
 require_numeric <- function(df,x) {

--- a/tests/testthat/test-cat.R
+++ b/tests/testthat/test-cat.R
@@ -41,3 +41,11 @@ test_that("pass vector or list", {
   expect_is(z, "list")
   expect_is(z[[1]], "gg")
 })
+
+test_that("cont_cat errors when receiving integer data for x", {
+  df$AGE <- as.integer(df$AGE)
+  expect_error(
+    cont_cat(df, x = "AGE", y = "WT"),
+    "column AGE is required to be character"
+  )
+})

--- a/tests/testthat/test-cont.R
+++ b/tests/testthat/test-cont.R
@@ -11,4 +11,8 @@ test_that("cont_cont works when receiving integer data for x", {
   df$AGE <- as.integer(df$AGE)
   ans <- cont_cont(df, x = "AGE", y = "WT")
   expect_is(ans, "gg")
+
+  tib <- dplyr::as_tibble(df)
+  ans <- cont_cont(tib, x = "AGE", y = "WT")
+  expect_is(ans, "gg")
 })

--- a/tests/testthat/test-cont.R
+++ b/tests/testthat/test-cont.R
@@ -6,3 +6,9 @@ test_that("scatter plot IDs [PMP-TEST-007]", {
   gg <- dv_pred(df, plot_id = TRUE, group = "ID", size = 4)
   expect_is(gg, "gg")
 })
+
+test_that("cont_cont works when receiving integer data for x", {
+  df$AGE <- as.integer(df$AGE)
+  ans <- cont_cont(df, x = "AGE", y = "WT")
+  expect_is(ans, "gg")
+})

--- a/tests/testthat/test-displays.R
+++ b/tests/testthat/test-displays.R
@@ -32,6 +32,11 @@ test_that("eta_covariate with integer data", {
   a <- eta_covariate(data, cont, etas)
   expect_type(a, "list")
   expect_s3_class(a[[3]], "gg")
+
+  tib <- dplyr::as_tibble(data)
+  a <- eta_covariate(tib, cont, etas)
+  expect_type(a, "list")
+  expect_s3_class(a[[3]], "gg")
 })
 
 test_that("cont_cat_panel", {

--- a/tests/testthat/test-displays.R
+++ b/tests/testthat/test-displays.R
@@ -27,6 +27,13 @@ test_that("eta_covariate", {
   expect_s3_class(a[[1]], "patchwork")
 })
 
+test_that("eta_covariate with integer data", {
+  data$AGE <- as.integer(data$AGE)
+  a <- eta_covariate(data, cont, etas)
+  expect_type(a, "list")
+  expect_s3_class(a[[3]], "gg")
+})
+
 test_that("cont_cat_panel", {
   a <- cont_cat_panel(data, x = cats, y = cont)
   expect_length(a, length(cont))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -238,3 +238,47 @@ test_that("remap_trans_arg() converts trans to transform", {
     list(transform = "log2")
   )
 })
+
+test_that("data type detection", {
+  dd <- data.frame(
+    num = c(1,2,3),
+    int = c(1L, 2L, 3L),
+    char = letters[1:3],
+    log = c(TRUE, FALSE, TRUE)
+  )
+  dd$fac <- factor(dd$num)
+  tib <- dplyr::as_tibble(dd)
+
+  # tests with data.frame
+  expect_error(pmplots:::require_discrete(dd, "num"))
+  expect_error(pmplots:::require_discrete(dd, "int"))
+  expect_null(pmplots:::require_discrete(dd, "char"))
+  expect_null(pmplots:::require_discrete(dd, "fac"))
+  expect_null(pmplots:::require_discrete(dd, "log"))
+
+  expect_null(pmplots:::require_numeric(dd, "num"))
+  expect_null(pmplots:::require_numeric(dd, "int"))
+  expect_error(pmplots:::require_numeric(dd, "char"))
+  expect_error(pmplots:::require_numeric(dd, "fac"))
+  expect_error(pmplots:::require_numeric(dd, "log"))
+
+  # tests with tibble
+  expect_error(pmplots:::require_discrete(tib, "num"))
+  expect_error(pmplots:::require_discrete(tib, "int"))
+  expect_null(pmplots:::require_discrete(tib, "char"))
+  expect_null(pmplots:::require_discrete(tib, "fac"))
+  expect_null(pmplots:::require_discrete(tib, "log"))
+
+  expect_null(pmplots:::require_numeric(tib, "num"))
+  expect_null(pmplots:::require_numeric(tib, "int"))
+  expect_error(pmplots:::require_numeric(tib, "char"))
+  expect_error(pmplots:::require_numeric(tib, "fac"))
+  expect_error(pmplots:::require_numeric(tib, "log"))
+
+  # test discrete
+  expect_false(pmplots:::.is_discrete(dd[["num"]]))
+  expect_false(pmplots:::.is_discrete(dd[["int"]]))
+  expect_true(pmplots:::.is_discrete(dd[["char"]]))
+  expect_true(pmplots:::.is_discrete(dd[["fac"]]))
+  expect_true(pmplots:::.is_discrete(dd[["log"]]))
+})


### PR DESCRIPTION
See #103 

The primary finding was an error that is generated when you pass integer x data into `eta_covariate()`; that function dispatches to `cont_cat()` which will generate an error, asking for `factor`, `character` or `logical`.  So that dispatch is fixed.

This PR also re-factors how discrete and continuous data are detected in checks across the package. This ensures consistent adjudication in different places, specifically the handling when calling `eta_covariate()`.
