### PR TITLE
ci: fix R <4.2 compatibility and test more R versions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,10 +19,19 @@ jobs:
         config:
           - os: ubuntu-20.04
             r: 3.6.3
+            # The latest versions of several dependencies require
+            # newer R versions.
+            rspm: 'https://packagemanager.posit.co/cran/__linux__/focal/2023-11-15'
           - os: ubuntu-20.04
             r: 4.0.5
+            # The latest versions of several dependencies require
+            # newer R versions.
+            rspm: 'https://packagemanager.posit.co/cran/__linux__/focal/2024-07-22'
           - os: ubuntu-20.04
             r: 4.1.3
+            # The latest versions of several dependencies require
+            # newer R versions.
+            rspm: 'https://packagemanager.posit.co/cran/__linux__/focal/2024-07-22'
           - os: ubuntu-20.04
             r: 4.2.3
           - os: ubuntu-20.04
@@ -37,18 +46,13 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           use-public-rspm: true
-      - name: Set evaluate source
-        # evaluate v0.24 requires R >= 4.0.
-        if: matrix.config.r == '3.6.3'
-        shell: bash
-        run: |
-          echo 'EVALUATE_PKG=github::r-lib/evaluate@v0.23' >>$GITHUB_ENV
+        env:
+          RSPM: ${{ matrix.config.rspm }}
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
             any::rcmdcheck
-            ${{ env.EVALUATE_PKG }}
-          upgrade: 'TRUE'
+          upgrade: ${{ (matrix.config.r == '3.6.3' || matrix.config.r == '4.0.5' || matrix.config.r == '4.1.3') && 'FALSE' || 'TRUE' }}
       - uses: r-lib/actions/check-r-package@v2
   release:
     if: github.ref_type == 'tag'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,6 +23,10 @@ jobs:
             r: 4.0.5
           - os: ubuntu-20.04
             r: 4.1.3
+          - os: ubuntu-20.04
+            r: 4.2.3
+          - os: ubuntu-20.04
+            r: 4.3.1
           - os: ubuntu-latest
             r: release
     env:


### PR DESCRIPTION
This resolves the R <4.2 CI failures encountered by gh-104.  It also add jobs for R 4.2 and 4.3.

To resolve the CI failures, I originally wanted to do a more targeted pin of ggstats.  But, as mentioned in the commit message, there are several other failures to deal with, so I ended up going with the blunter approach of using a date-pinned RSPM.