### PR TITLE
release/0.5.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pmplots
 Type: Package
 Title: Plots for Pharmacometrics
-Version: 0.5.0.9000
+Version: 0.5.1
 Authors@R: c(
        person("Kyle T", "Baron", "", "kyleb@metrumrg.com", c("aut", "cre")),
        person(given = "Kyle", family = "Meyer", role = "ctb", email = "kylem@metrumrg.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,12 @@
-# pmplots (development version)
+# pmplots 0.5.1
+
+## Bugs fixed
+
+- `eta_covariate()` now calls `eta_cont()` rather than `eta_cat()` when data for 
+  the x-axis is `integer`, fixing an error that was generated from `eta_cat()`, 
+  which always expects `factor`, `character`, or `logical`; other internal 
+  updates have been made to ensure consistent treatment of `integer` data as 
+  continuous rather than discrete (#104).
 
 # pmplots 0.5.0
 


### PR DESCRIPTION
# pmplots 0.5.1

## Bugs fixed

- `eta_covariate()` now calls `eta_cont()` rather than `eta_cat()` when data for 
  the x-axis is `integer`, fixing an error that was generated from `eta_cat()`, 
  which always expects `factor`, `character`, or `logical`; other internal 
  updates have been made to ensure consistent treatment of `integer` data as 
  continuous rather than discrete (#104).

[pmplots_0.5.1.scorecard.pdf](https://github.com/user-attachments/files/17258366/pmplots_0.5.1.scorecard.pdf)

