### PR TITLE
ci: update ubuntu-20.04 jobs to ubuntu-22.04

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,24 +17,24 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             r: 3.6.3
             # The latest versions of several dependencies require
             # newer R versions.
-            rspm: 'https://packagemanager.posit.co/cran/__linux__/focal/2023-11-15'
-          - os: ubuntu-20.04
+            rspm: 'https://packagemanager.posit.co/cran/__linux__/jammy/2023-11-15'
+          - os: ubuntu-22.04
             r: 4.0.5
             # The latest versions of several dependencies require
             # newer R versions.
-            rspm: 'https://packagemanager.posit.co/cran/__linux__/focal/2024-07-22'
-          - os: ubuntu-20.04
+            rspm: 'https://packagemanager.posit.co/cran/__linux__/jammy/2024-07-22'
+          - os: ubuntu-22.04
             r: 4.1.3
             # The latest versions of several dependencies require
             # newer R versions.
-            rspm: 'https://packagemanager.posit.co/cran/__linux__/focal/2024-07-22'
-          - os: ubuntu-20.04
+            rspm: 'https://packagemanager.posit.co/cran/__linux__/jammy/2024-07-22'
+          - os: ubuntu-22.04
             r: 4.2.3
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             r: 4.3.1
           - os: ubuntu-latest
             r: release


### PR DESCRIPTION
The ubuntu-20.04 image is deprecated as of 2025-02-01 and is scheduled to be retired on 2025-04-01.

https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions