### PR TITLE
update CI and make tests compatible with GGally 2.3.0

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,6 +37,9 @@ jobs:
             pinned: true
           - os: ubuntu-22.04
             r: 4.2.3
+            # GGally v2.3.0 requires R >= 4.3.
+            ggally_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2025-07-16/src/contrib/GGally_2.2.1.tar.gz'
+            pinned: true
           - os: ubuntu-22.04
             r: 4.3.1
           - os: ubuntu-latest
@@ -56,6 +59,7 @@ jobs:
           extra-packages: |
             any::pkgdown
             any::rcmdcheck
+            ${{ matrix.config.ggally_pkg }}
           upgrade: ${{ matrix.config.pinned && 'FALSE' || 'TRUE' }}
       - uses: r-lib/actions/check-r-package@v2
       - name: Check pkgdown

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,16 +22,19 @@ jobs:
             # The latest versions of several dependencies require
             # newer R versions.
             rspm: 'https://packagemanager.posit.co/cran/__linux__/jammy/2023-11-15'
+            pinned: true
           - os: ubuntu-22.04
             r: 4.0.5
             # The latest versions of several dependencies require
             # newer R versions.
             rspm: 'https://packagemanager.posit.co/cran/__linux__/jammy/2024-07-22'
+            pinned: true
           - os: ubuntu-22.04
             r: 4.1.3
             # The latest versions of several dependencies require
             # newer R versions.
             rspm: 'https://packagemanager.posit.co/cran/__linux__/jammy/2024-07-22'
+            pinned: true
           - os: ubuntu-22.04
             r: 4.2.3
           - os: ubuntu-22.04
@@ -53,7 +56,7 @@ jobs:
           extra-packages: |
             any::pkgdown
             any::rcmdcheck
-          upgrade: ${{ (matrix.config.r == '3.6.3' || matrix.config.r == '4.0.5' || matrix.config.r == '4.1.3') && 'FALSE' || 'TRUE' }}
+          upgrade: ${{ matrix.config.pinned && 'FALSE' || 'TRUE' }}
       - uses: r-lib/actions/check-r-package@v2
       - name: Check pkgdown
         shell: Rscript {0}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,6 +22,13 @@ jobs:
             # The latest versions of several dependencies require
             # newer R versions.
             rspm: 'https://packagemanager.posit.co/cran/__linux__/jammy/2023-11-15'
+            # pmplots depends on a ggplot2 version that's newer than
+            # what's in the above rspm URL.  The ggplot2 on CRAN in
+            # turn requires several packages that require an R version
+            # newer than 3.6.  Override CRAN to a snapshot that avoids
+            # these incompatibilities but still has a new enough
+            # ggplot2.
+            cran_override: 'https://mpn.metworx.com/snapshots/stable/2024-06-12'
             pinned: true
           - os: ubuntu-22.04
             r: 4.0.5
@@ -54,12 +61,15 @@ jobs:
           use-public-rspm: true
         env:
           RSPM: ${{ matrix.config.rspm }}
+          CRAN: ${{ matrix.config.cran_override }}
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
             any::pkgdown
             any::rcmdcheck
             ${{ matrix.config.ggally_pkg }}
+            ${{ matrix.config.patchwork_pkg }}
+            ${{ matrix.config.scales_pkg }}
           upgrade: ${{ matrix.config.pinned && 'FALSE' || 'TRUE' }}
       - uses: r-lib/actions/check-r-package@v2
       - name: Check pkgdown

--- a/tests/testthat/test-pairs.R
+++ b/tests/testthat/test-pairs.R
@@ -5,12 +5,12 @@ etas <- c("ETA1//ETA-CL", "ETA2//ETA-V2", "ETA3//ETA-KA")
 
 test_that("pairs plots y [PMP-TEST-027]", {
   p <- pairs_plot(df, y = c("ALB", "WT", "SCR"))
-  expect_is(p, "gg")
+  expect_is(p, "ggmatrix")
 })
 
 test_that("eta pairs plots etas [PMP-TEST-028]", {
   p <- eta_pairs(df, etas = etas)
-  expect_is(p, "gg")
+  expect_is(p, "ggmatrix")
 })
 
 test_that("upper and lower funs are used in pairs plots [PMP-TEST-029]", {

--- a/tests/testthat/test-pm.R
+++ b/tests/testthat/test-pm.R
@@ -206,7 +206,7 @@ test_that("eta pairs [PMP-TEST-042]", {
   expect_x(p, "ETA1", "ETA-CL")
 
   p2 <- pairs_plot(df, c("ETA1", "ETA2"))
-  expect_is(p2,"gg")
+  expect_is(p2, "ggmatrix")
 
   p <- eta_pairs(
     df,
@@ -214,7 +214,7 @@ test_that("eta pairs [PMP-TEST-042]", {
     smooth_color = "red",
     smooth_lty=1
   )
-  expect_is(p, "gg")
+  expect_is(p, "ggmatrix")
 
   x <- pmplots:::pairs_lower(
     df,
@@ -227,7 +227,7 @@ test_that("eta pairs [PMP-TEST-042]", {
 
 test_that("pairs_plot with latex [PMP-TEST-043]", {
   x <- pairs_plot(df, c("ETA1//ETA$_1$", "ETA2//ETA$_2$", "ETA3//ETA3"))
-  expect_is(x,"gg")
+  expect_is(x, "ggmatrix")
 })
 
 test_that("qq [PMP-TEST-044]", {
@@ -293,7 +293,7 @@ test_that("eta labs [PMP-TEST-048]", {
 
 test_that("pairs plot with expression [PMP-TEST-049]", {
   p <- pairs_plot(df, c("CWRES", "WRES", "DV//Conc ($\\mu$M)"))
-  expect_is(p, "gg")
+  expect_is(p, "ggmatrix")
 })
 
 test_that("dv_pred_ipred issue-6 [PMP-TEST-050]", {


### PR DESCRIPTION
The dependency installation steps for the R 3.6 and R 4.2 jobs are failing due to CRAN updates.  The first three commits resolve those failures.

---

The GGally 2.3.0 update triggers the following test failures:

```
── 1. Failure ('test-pairs.R:8:3'): pairs plots y [PMP-TEST-027] ───────────────
`p` inherits from `'ggmatrix'/'GGally::ggmatrix'/'S7_object'` not `'character'`.

── 2. Failure ('test-pairs.R:13:3'): eta pairs plots etas [PMP-TEST-028] ───────
`p` inherits from `'ggmatrix'/'GGally::ggmatrix'/'S7_object'` not `'character'`.

── 3. Failure ('test-pm.R:209:3'): eta pairs [PMP-TEST-042] ────────────────────
`p2` inherits from `'ggmatrix'/'GGally::ggmatrix'/'S7_object'` not `'character'`.

── 4. Failure ('test-pm.R:217:3'): eta pairs [PMP-TEST-042] ────────────────────
`p` inherits from `'ggmatrix'/'GGally::ggmatrix'/'S7_object'` not `'character'`.

── 5. Failure ('test-pm.R:230:3'): pairs_plot with latex [PMP-TEST-043] ────────
`x` inherits from `'ggmatrix'/'GGally::ggmatrix'/'S7_object'` not `'character'`.

── 6. Failure ('test-pm.R:296:3'): pairs plot with expression [PMP-TEST-049] ───
`p` inherits from `'ggmatrix'/'GGally::ggmatrix'/'S7_object'` not `'character'`.
```

These last commit of this PR updates those assertions to be compatible with the latest GGally and with earlier versions.
