### PR TITLE
Release/0.5.2

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -68,8 +68,6 @@ jobs:
             any::pkgdown
             any::rcmdcheck
             ${{ matrix.config.ggally_pkg }}
-            ${{ matrix.config.patchwork_pkg }}
-            ${{ matrix.config.scales_pkg }}
           upgrade: ${{ matrix.config.pinned && 'FALSE' || 'TRUE' }}
       - uses: r-lib/actions/check-r-package@v2
       - name: Check pkgdown

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -44,8 +44,9 @@ jobs:
             pinned: true
           - os: ubuntu-22.04
             r: 4.2.3
-            # GGally v2.3.0 requires R >= 4.3.
-            ggally_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2025-07-16/src/contrib/GGally_2.2.1.tar.gz'
+            # The latest versions of several dependencies require
+            # newer R versions.
+            rspm: 'https://packagemanager.posit.co/cran/__linux__/jammy/2025-07-16'
             pinned: true
           - os: ubuntu-22.04
             r: 4.3.1
@@ -67,7 +68,6 @@ jobs:
           extra-packages: |
             any::pkgdown
             any::rcmdcheck
-            ${{ matrix.config.ggally_pkg }}
           upgrade: ${{ matrix.config.pinned && 'FALSE' || 'TRUE' }}
       - uses: r-lib/actions/check-r-package@v2
       - name: Check pkgdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pmplots
 Type: Package
 Title: Plots for Pharmacometrics
-Version: 0.5.1
+Version: 0.5.2
 Authors@R: c(
        person("Kyle T", "Baron", "", "kyleb@metrumrg.com", c("aut", "cre")),
        person(given = "Kyle", family = "Meyer", role = "ctb", email = "kylem@metrumrg.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# pmpots 0.5.2
+
+- 
+
 # pmplots 0.5.1
 
 ## Bugs fixed

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 - Prefer `ggplot2::is_ggplot()` when available (#115).
 
-- Update CI and make tests compatible with GGally 2.2.0 (#114). 
+- Update CI and make tests compatible with GGally 2.3.0 (#114).
 
 # pmplots 0.5.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 - Fix some test failures related to ggplot2 version 4.0 (#117).
 
-- Add S4 as optional dependency to slience `R CMD check` warning (#117).
+- Add S4 as optional dependency to silence `R CMD check` warning (#117).
 
 - Prefer `ggplot2::is_ggplot()` when available (#115).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## Internal compatibility changes
 
+- Fix some test failures related to ggplot2 version 4.0 (#117).
+
+- Add S4 as optional dependency to slience `R CMD check` warning (#117).
+
 - Prefer `ggplot2::is_ggplot()` when available (#115).
 
 - Update CI and make tests compatible with GGally 2.2.0 (#114). 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
-# pmpots 0.5.2
+# pmplots 0.5.2
 
-- 
+## Internal compatibility changes
+
+- Prefer `ggplot2::is_ggplot()` when available (#115).
+
+- Update CI and make tests compatible with GGally 2.2.0 (#114). 
 
 # pmplots 0.5.1
 


### PR DESCRIPTION
# TODO

- [x] Merge #117 to main and pull into this PR
- [x] Address latest [CI failure](https://github.com/metrumresearchgroup/pmplots/actions/runs/18407889662/job/52452138112) (km)

# pmplots 0.5.2

## Internal compatibility changes

- Fix some test failures related to ggplot2 version 4.0 (#117).

- Add S4 as optional dependency to slience `R CMD check` warning (#117).

- Prefer `ggplot2::is_ggplot()` when available (#115).

- Update CI and make tests compatible with GGally 2.2.0 (#114). 