### PR TITLE
Adjust for compatibility with ggplot2 4.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,7 @@ Suggests:
   knitr, 
   yaml, 
   miniUI, 
+  S7,
   shiny, 
   rmarkdown
 Depends: ggplot2 (>= 3.5.0)

--- a/R/dv_pred_ipred.R
+++ b/R/dv_pred_ipred.R
@@ -293,7 +293,9 @@ dv_pred_ipred_impl <- function(data,
     axtx <- element_text(size = ggplot2::rel(axis.text.rel))
     use_theme <- use_theme + theme(axis.text = axtx)
   }
-  if(inherits(plot.margin, "margin")) {
+
+  # ggplot2 4.0.0 changed the class to ggplot2::margin.
+  if (inherits(plot.margin, "margin") || inherits(plot.margin, "ggplot2::margin")) {
     use_theme <- use_theme + theme(plot.margin = plot.margin)
   }
 

--- a/tests/testthat/test-pm.R
+++ b/tests/testthat/test-pm.R
@@ -149,7 +149,13 @@ test_that("eta cat cont hist [PMP-TEST-040]", {
   p <- eta_hist(df,etas)
   expect_is(p, "list")
   p <- p[[1]]
-  expect_titles(p, "ETA-CL", "count")
+  # As of ggplot2 4.0.0, $labels records only explicitly set labels.
+  if (utils::packageVersion("ggplot2") < "4.0.0") {
+    expect_titles(p, "ETA-CL", "count")
+  } else {
+    expect_titles(p, "ETA-CL", NULL)
+  }
+
 
   p <- eta_cont(df, x="WT//Weight (kg)", y=etas)
   expect_is(p, "list")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -98,15 +98,26 @@ test_that("rot_xy", {
   l <- list(a = g1, b = g2)
   lp <- list(a = p1, b = p2)
 
-  nuke_env <- function(xs) {
-    for (i in seq_along(xs)) {
-      if (identical(names(xs[i]), "plot_env")) {
-        xs[[i]] <- "CLOBBERED"
-      } else if (is.list(xs[[i]])) {
-        xs[[i]] <- nuke_env(xs[[i]])
+  if (utils::packageVersion("ggplot2") < "4.0.0") {
+    # Overwrite plot_env because it trips up the expect_equal calls on R < 4.0.
+    # For unknown reasons, it doesn't affect later R versions.
+    #
+    # https://github.com/metrumresearchgroup/pmplots/pull/96#discussion_r1681145034
+    nuke_env <- function(xs) {
+      for (i in seq_along(xs)) {
+        if (identical(names(xs[i]), "plot_env")) {
+          xs[[i]] <- "CLOBBERED"
+        } else if (is.list(xs[[i]])) {
+          xs[[i]] <- nuke_env(xs[[i]])
+        }
       }
+      return(xs)
     }
-    return(xs)
+  } else {
+    # The above workaround isn't compatible with the S7 classes used in ggplot2
+    # >= 4.0.0, but it's not necessary anyway because ggplot2 4.0.0 requires R
+    # 4.1.
+    nuke_env <- identity
   }
 
   # Check if these are the same, ignoring plot_env


### PR DESCRIPTION
 * Fix the test failures hit into at https://github.com/metrumresearchgroup/pmplots/pull/116#issuecomment-3281321534 (see messages of first three commits for details)

 * Add S7 as an optional dependency to silence an `R CMD check` warning.