### PR TITLE
boxwork: support extending plot with aes fill

### DIFF
--- a/R/box.R
+++ b/R/box.R
@@ -15,7 +15,9 @@ box_labels <- function(df, x, y) {
 #' @param y character name for y-axis data
 #' @param xs see \code{\link{defcx}}
 #' @param ys see \code{\link{defy}}
-#' @param fill passed to \code{geom_boxplot}
+#' @param fill passed to [ggplot2::geom_boxplot()]. Specifying `NULL` disables
+#'   relaying the value to `geom_boxplot` and is required for modifying the fill
+#'   of the returned plot with [ggplot2::aes()].
 #' @param alpha passed to \code{geom_boxplot}
 #' @param hline used to draw horizontal reference line
 #' @param title passed to \code{ggtitle}
@@ -89,7 +91,9 @@ boxwork <- function(df, x, y, xs=defcx(), ys=defy(),
   do_points <- !missing(points) & !is.null(points)
   if(do_points) {
     outlier.shape <- NA
-    fill <- NA
+    if (!is.null(fill)) {
+      fill <- NA
+    }
     def <- list(col = "grey", position  = position_jitter(height = 0))
     if(is.list(points)) {
       if("jitter_width" %in% names(points)) {
@@ -103,7 +107,13 @@ boxwork <- function(df, x, y, xs=defcx(), ys=defy(),
     }
     p <- p + do.call(geom_point,points)
   }
-  p <- p + geom_boxplot(fill=fill, alpha = alpha, outlier.shape = outlier.shape, ...)
+
+  boxargs <- list(alpha = alpha, outlier.shape = outlier.shape, ...)
+  if (!is.null(fill)) {
+    boxargs <- c(fill = fill, boxargs)
+  }
+  p <- p + do.call(geom_boxplot, boxargs)
+
   p <- p + yscale + xscale
   if(is.numeric(hline)) {
     p <- p + geom_hline(

--- a/man/boxwork.Rd
+++ b/man/boxwork.Rd
@@ -31,7 +31,9 @@ boxwork(
 
 \item{ys}{see \code{\link{defy}}}
 
-\item{fill}{passed to \code{geom_boxplot}}
+\item{fill}{passed to \code{\link[ggplot2:geom_boxplot]{ggplot2::geom_boxplot()}}. Specifying \code{NULL} disables
+relaying the value to \code{geom_boxplot} and is required for modifying the fill
+of the returned plot with \code{\link[ggplot2:aes]{ggplot2::aes()}}.}
 
 \item{alpha}{passed to \code{geom_boxplot}}
 

--- a/tests/testthat/test-cat.R
+++ b/tests/testthat/test-cat.R
@@ -33,6 +33,21 @@ test_that("points on top of box plot issue-13 [PMP-TEST-003]", {
   expect_false(identical(a,c))
 })
 
+test_that("cont_cat supports overriding fill", {
+  p <- cont_cat(id, x = "CPc", y = "WT")
+  expect_identical(unique(layer_data(p)[["fill"]]), pm_opts[["boxplot.fill"]])
+
+  pm_opts[["boxplot.fill"]] <- NULL
+
+  p <- cont_cat(id, x = "CPc", y = "WT") + aes(fill = STUDYc)
+  expect_length(unique(layer_data(p)[["fill"]]), nlevels(id$STUDYc))
+
+  p <- cont_cat(id, x = "CPc", y = "WT", points = TRUE) + aes(fill = STUDYc)
+  expect_length(unique(layer_data(p, 2)[["fill"]]), nlevels(id$STUDYc))
+
+  pm_opts$reset()
+})
+
 test_that("pass vector or list", {
   y <- list("WT", "SCR")
   x <- "STUDYc"

--- a/tests/testthat/test-cat.R
+++ b/tests/testthat/test-cat.R
@@ -37,6 +37,9 @@ test_that("cont_cat supports overriding fill", {
   p <- cont_cat(id, x = "CPc", y = "WT")
   expect_identical(unique(layer_data(p)[["fill"]]), pm_opts[["boxplot.fill"]])
 
+  p <- cont_cat(id, x = "CPc", y = "WT", fill = NULL) + aes(fill = STUDYc)
+  expect_length(unique(layer_data(p)[["fill"]]), nlevels(id$STUDYc))
+
   pm_opts[["boxplot.fill"]] <- NULL
 
   p <- cont_cat(id, x = "CPc", y = "WT") + aes(fill = STUDYc)


### PR DESCRIPTION
A caller may want to extend the plot returned by boxwork with

    ... + aes(fill = foo)

That has no effect because the value of fill that boxwork passes to geom_boxplot always wins out.  ggplot2 does not provide a way to specify a fill value that means "unset".

Work around this by _not_ passing fill to geom_boxplot when it's NULL.