### PR TITLE
displays: expose boxwork's points argument

### DIFF
--- a/R/displays.R
+++ b/R/displays.R
@@ -4,14 +4,14 @@ class_pm_display <- function(x) {
   x
 }
 
-diagnostic_display_list <- function(df, x, y, fun_cat, fun_cont) {
+diagnostic_display_list <- function(df, x, y, fun_cat, fun_cont, points) {
   out <- vector(mode = "list", length = length(y))
   for(i in seq_along(y)) {
     out[[i]] <- lapply(seq_along(x), function(ii) {
       col <- col_label(x[[ii]])[[1]]
       require_column(df, col)
       if(.is_discrete(df[[col]])) {
-        p <- fun_cat(df, x = x[[ii]], y = y[[i]])
+        p <- fun_cat(df, x = x[[ii]], y = y[[i]], points = points)
       } else {
         p <- fun_cont(df, x = x[[ii]], y = y[[i]])
       }
@@ -35,6 +35,7 @@ diagnostic_display_list <- function(df, x, y, fun_cat, fun_cont) {
 #' @param tag_levels passed to [patchwork::plot_annotation()].
 #' @param transpose logical; if `TRUE`, output will be transposed to group
 #' plots by the covariate, rather than the `ETA`; see **Examples**.
+#' @param points passed to [boxwork()] when plotting categorical covariates.
 #'
 #' @details
 #' Pass `ncol = NULL` or another non-numeric value to bypass arranging plots
@@ -69,12 +70,12 @@ diagnostic_display_list <- function(df, x, y, fun_cat, fun_cont) {
 #' @md
 #' @export
 eta_covariate <- function(df, x, y, ncol = 2, tag_levels = NULL, byrow = NULL,
-                          transpose = FALSE) {
+                          transpose = FALSE, points = NULL) {
   require_patchwork()
   if(missing(ncol) && length(x)==1) {
     ncol <- 1
   }
-  p <- eta_covariate_list(df, x, y, transpose)
+  p <- eta_covariate_list(df, x, y, transpose, points = points)
   if(is.numeric(ncol)) {
     p <- lapply(p, pm_grid, ncol = ncol, byrow = byrow)
   }
@@ -86,8 +87,8 @@ eta_covariate <- function(df, x, y, ncol = 2, tag_levels = NULL, byrow = NULL,
 
 #' @rdname eta_covariate
 #' @export
-eta_covariate_list <- function(df, x, y, transpose = FALSE) {
-  p  <- diagnostic_display_list(df, x, y, eta_cat, eta_cont)
+eta_covariate_list <- function(df, x, y, transpose = FALSE, points = NULL) {
+  p <- diagnostic_display_list(df, x, y, eta_cat, eta_cont, points)
   labx <- col_label_col(x)
   laby <- col_label_col(y)
   p  <- lapply(p, setNames, nm = labx)
@@ -129,12 +130,13 @@ eta_covariate_list <- function(df, x, y, transpose = FALSE) {
 #' @seealso [cwres_covariate()], [eta_covariate()]
 #' @md
 #' @export
-npde_covariate <- function(df, x, ncol = 2, tag_levels = NULL, byrow = NULL) {
+npde_covariate <- function(df, x, ncol = 2, tag_levels = NULL, byrow = NULL,
+                           points = NULL) {
   require_patchwork()
   if(missing(ncol) && length(x)==1) {
     ncol <- 1
   }
-  p <- npde_covariate_list(df, x)
+  p <- npde_covariate_list(df, x, points = points)
   if(is.numeric(ncol)) {
     p <- pm_grid(p, ncol = ncol, byrow = byrow)
   }
@@ -144,8 +146,15 @@ npde_covariate <- function(df, x, ncol = 2, tag_levels = NULL, byrow = NULL) {
 
 #' @rdname npde_covariate
 #' @export
-npde_covariate_list <- function(df, x) {
-  p  <- diagnostic_display_list(df, x, pm_axis_npde(), npde_cat, npde_cont)
+npde_covariate_list <- function(df, x, points = NULL) {
+  p <- diagnostic_display_list(
+    df,
+    x,
+    pm_axis_npde(),
+    npde_cat,
+    npde_cont,
+    points
+  )
   p <- p[[1]]
   labx <- col_label_col(x)
   names(p) <- labx
@@ -183,12 +192,13 @@ npde_covariate_list <- function(df, x) {
 #' @seealso [npde_covariate()], [eta_covariate()]
 #' @md
 #' @export
-cwres_covariate <- function(df, x, ncol = 2, tag_levels = NULL, byrow = NULL) {
+cwres_covariate <- function(df, x, ncol = 2, tag_levels = NULL, byrow = NULL,
+                            points = NULL) {
   require_patchwork()
   if(missing(ncol) && length(x)==1) {
     ncol <- 1
   }
-  p <- cwres_covariate_list(df, x)
+  p <- cwres_covariate_list(df, x, points = points)
   if(is.numeric(ncol)) {
     p <- pm_grid(p, ncol = ncol, byrow = byrow)
   }
@@ -198,8 +208,15 @@ cwres_covariate <- function(df, x, ncol = 2, tag_levels = NULL, byrow = NULL) {
 
 #' @rdname cwres_covariate
 #' @export
-cwres_covariate_list <- function(df, x) {
-  p  <- diagnostic_display_list(df, x, pm_axis_cwres(), cwres_cat, cwres_cont)
+cwres_covariate_list <- function(df, x, points = NULL) {
+  p <- diagnostic_display_list(
+    df,
+    x,
+    pm_axis_cwres(),
+    cwres_cat,
+    cwres_cont,
+    points
+  )
   p <- p[[1]]
   labx <- col_label_col(x)
   names(p) <- labx

--- a/R/displays.R
+++ b/R/displays.R
@@ -479,7 +479,7 @@ cwres_scatter <- function(df, xname = "value",
 #' Alternatively, get the component plots to be arranged by the user
 #' (`cont_cat_panel_list()`)
 #'
-#' @inheritParams eta_covariate
+#' @inheritParams eta_covariate 
 #'
 #' @param x character `col//title` for the categorical covariates to
 #' plot on x-axis; see [col_label()].
@@ -523,9 +523,10 @@ cwres_scatter <- function(df, xname = "value",
 #' @md
 #' @export
 cont_cat_panel <- function(df, x, y, ncol = 2, tag_levels = NULL,
-                            byrow = FALSE, transpose = FALSE, ...) {
+                           byrow = FALSE, transpose = FALSE, points = NULL,
+                           ...) {
   require_patchwork()
-  p <- cont_cat_panel_list(df, x, y, transpose, ...)
+  p <- cont_cat_panel_list(df, x, y, transpose, points = points, ...)
   if(is.numeric(ncol)) {
     p <- lapply(p, pm_grid, ncol = ncol, byrow = byrow)
   }

--- a/man/cont_cat_panel.Rd
+++ b/man/cont_cat_panel.Rd
@@ -13,6 +13,7 @@ cont_cat_panel(
   tag_levels = NULL,
   byrow = FALSE,
   transpose = FALSE,
+  points = NULL,
   ...
 )
 
@@ -36,6 +37,8 @@ plot on y-axis; see \code{\link[=col_label]{col_label()}}.}
 \item{transpose}{logical; if \code{TRUE}, output will be transposed to
 group plots by the categorical covariates rather than the continuous
 covariates.}
+
+\item{points}{passed to \code{\link[=boxwork]{boxwork()}} when plotting categorical covariates.}
 
 \item{...}{additional arguments passed to \code{\link[=cont_cat]{cont_cat()}}.}
 }

--- a/man/cwres_covariate.Rd
+++ b/man/cwres_covariate.Rd
@@ -5,9 +5,16 @@
 \alias{cwres_covariate_list}
 \title{Create CWRES versus covariate displays}
 \usage{
-cwres_covariate(df, x, ncol = 2, tag_levels = NULL, byrow = NULL)
+cwres_covariate(
+  df,
+  x,
+  ncol = 2,
+  tag_levels = NULL,
+  byrow = NULL,
+  points = NULL
+)
 
-cwres_covariate_list(df, x)
+cwres_covariate_list(df, x, points = NULL)
 }
 \arguments{
 \item{df}{a data frame to plot.}
@@ -20,6 +27,8 @@ see \code{\link[=col_label]{col_label()}}.}
 \item{tag_levels}{passed to \code{\link[patchwork:plot_annotation]{patchwork::plot_annotation()}}.}
 
 \item{byrow}{passed to \code{\link[=pm_grid]{pm_grid()}}.}
+
+\item{points}{passed to \code{\link[=boxwork]{boxwork()}} when plotting categorical covariates.}
 }
 \value{
 \code{cwres_covariate()} returns single graphic of scatter plot diagnostics

--- a/man/eta_covariate.Rd
+++ b/man/eta_covariate.Rd
@@ -12,10 +12,11 @@ eta_covariate(
   ncol = 2,
   tag_levels = NULL,
   byrow = NULL,
-  transpose = FALSE
+  transpose = FALSE,
+  points = NULL
 )
 
-eta_covariate_list(df, x, y, transpose = FALSE)
+eta_covariate_list(df, x, y, transpose = FALSE, points = NULL)
 }
 \arguments{
 \item{df}{a data frame to plot.}
@@ -33,6 +34,8 @@ see \code{\link[=col_label]{col_label()}}.}
 
 \item{transpose}{logical; if \code{TRUE}, output will be transposed to group
 plots by the covariate, rather than the \code{ETA}; see \strong{Examples}.}
+
+\item{points}{passed to \code{\link[=boxwork]{boxwork()}} when plotting categorical covariates.}
 }
 \value{
 \code{eta_covariate()} returns a list of plots arranged in graphics as a

--- a/man/npde_covariate.Rd
+++ b/man/npde_covariate.Rd
@@ -5,9 +5,9 @@
 \alias{npde_covariate_list}
 \title{Create NPDE versus covariate displays}
 \usage{
-npde_covariate(df, x, ncol = 2, tag_levels = NULL, byrow = NULL)
+npde_covariate(df, x, ncol = 2, tag_levels = NULL, byrow = NULL, points = NULL)
 
-npde_covariate_list(df, x)
+npde_covariate_list(df, x, points = NULL)
 }
 \arguments{
 \item{df}{a data frame to plot.}
@@ -20,6 +20,8 @@ see \code{\link[=col_label]{col_label()}}.}
 \item{tag_levels}{passed to \code{\link[patchwork:plot_annotation]{patchwork::plot_annotation()}}.}
 
 \item{byrow}{passed to \code{\link[=pm_grid]{pm_grid()}}.}
+
+\item{points}{passed to \code{\link[=boxwork]{boxwork()}} when plotting categorical covariates.}
 }
 \value{
 \code{npde_covariate()} returns single graphic of scatter plot diagnostics

--- a/tests/testthat/test-displays.R
+++ b/tests/testthat/test-displays.R
@@ -364,9 +364,13 @@ test_that("display plots expose points arg", {
   # Expect three layers: geom_boxplot, geom_hline, and geom_point.
   expect_length(pws[[1]][[1]]$layers, 3)
 
-  ps <- npde_covariate(data, cats, points = TRUE)
+  ps <- npde_covariate(id, cats, points = TRUE)
   expect_length(ps[[1]]$layers, 3)
 
-  ps <- cwres_covariate(data, cats, points = TRUE)
+  ps <- cwres_covariate(id, cats, points = TRUE)
   expect_length(ps[[1]]$layers, 3)
+
+  # Expect two layers: geom_boxplot and geom_point.
+  ps <- cont_cat_panel(id, cats, cont, points = TRUE)
+  expect_length(ps[[1]]$layers, 2)
 })

--- a/tests/testthat/test-displays.R
+++ b/tests/testthat/test-displays.R
@@ -358,3 +358,15 @@ test_that("display plots accept list", {
   expect_s3_class(npde_covariate(data, cont), "patchwork")
   expect_s3_class(cwres_covariate(data, cats), "patchwork")
 })
+
+test_that("display plots expose points arg", {
+  pws <- eta_covariate(data, cats, etas, points = TRUE)
+  # Expect three layers: geom_boxplot, geom_hline, and geom_point.
+  expect_length(pws[[1]][[1]]$layers, 3)
+
+  ps <- npde_covariate(data, cats, points = TRUE)
+  expect_length(ps[[1]]$layers, 3)
+
+  ps <- cwres_covariate(data, cats, points = TRUE)
+  expect_length(ps[[1]]$layers, 3)
+})


### PR DESCRIPTION
Each of the `*_covariate` display functions eventually goes through boxwork for categorical covariates.  Enable callers to display and customize jittered points via boxwork's `points` argument.