### PR TITLE
ci: specify MPN as repo for site workflow

### DIFF
--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -17,11 +17,13 @@ jobs:
         with:
           # Fetch tags for more informative git-describe output.
           fetch-depth: 0
+      - uses: metrumresearchgroup/actions/mpn-latest@v1
       - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: release
           use-public-rspm: true
+          extra-repositories: 'https://mpn.metworx.com/snapshots/stable/${{ env.MPN_LATEST }}'
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           # The latest pkgdown release (v2.1.1) is not compatible with the


### PR DESCRIPTION
Like the main CI workflow (6d91a7b), the site workflow needs MPN in order to install yspec, a suggested dependency as of the 0.6.0 release.