### PR TITLE
boxwork: call pm_col_id not pm_col_tad to get ID column

### DIFF
--- a/R/box.R
+++ b/R/box.R
@@ -75,7 +75,7 @@ boxwork <- function(df, x, y, xs=defcx(), ys=defy(),
                     ...) {
 
   if(shown) {
-    idcol <- pm_col_tad()
+    idcol <- pm_col_id()
     require_column(df, idcol)
     .sum <- box_labels(df, x, y, idcol)
     xs$labels <- paste0(.sum[,x], "\nn=", .sum[,"n"], "\nN=", .sum[,"N"])

--- a/tests/testthat/test-cat.R
+++ b/tests/testthat/test-cat.R
@@ -67,3 +67,13 @@ test_that("cont_cat errors when receiving integer data for x", {
     "column AGE is required to be character"
   )
 })
+
+test_that("cont_cat works with minimum columns", {
+  x <- "STUDYc"
+  y <- c("WT", "SCR")
+  data <- dplyr::select(df, "ID", any_of(x), any_of(y))
+  p <- cont_cat(data, x, y)
+  expect_length(p, 2)
+  expect_is(p[[1]], "gg")
+  expect_is(p[[2]], "gg")
+})


### PR DESCRIPTION
As part of the aliases feature (#124), a hard-coded "ID" was mistakenly replaced by a call to `pm_col_tad` rather than `pm_col_id`.