### PR TITLE
Release 0.6.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pmplots
 Type: Package
 Title: Plots for Pharmacometrics
-Version: 0.6.0.9000
+Version: 0.6.1
 Authors@R: c(
        person("Kyle T", "Baron", "", "kyleb@metrumrg.com", c("aut", "cre")),
        person(given = "Kyle", family = "Meyer", role = "ctb", email = "kylem@metrumrg.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,10 @@
-# pmplots (development version)
+# pmplots 0.6.1
+
+## Bugs fixed
+
+- Fixed a bug introduced in #124, where a hard-coded "ID" was mistakenly 
+  replaced by a call to `pm_col_tad()` rather than `pm_col_id()` (#131).
+
 
 # pmplots 0.6.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## Bugs fixed
 
 - Fixed a bug introduced in #124, where a hard-coded "ID" was mistakenly 
-  replaced by a call to `pm_col_tad()` rather than `pm_col_id()` (#131).
+  replaced by a call to `pm_col_tad()` rather than `pm_col_id()`. (#131)
 
 
 # pmplots 0.6.0


### PR DESCRIPTION
# pmplots 0.6.1

## Bugs fixed

- Fixed a bug introduced in #124, where a hard-coded "ID" was mistakenly 
  replaced by a call to `pm_col_tad()` rather than `pm_col_id()`. (#131)
